### PR TITLE
Fix envelope signing in tutorials and examples

### DIFF
--- a/examples/01-basic-xid/create_basic_xid.sh
+++ b/examples/01-basic-xid/create_basic_xid.sh
@@ -107,8 +107,11 @@ ATTESTATION=$(envelope assertion add pred-obj string "projectCount" string "5" "
 # Save the attestation
 echo "$ATTESTATION" > output/bwhacker-skill-attestation.envelope
 
-# Sign the attestation with private key
-SIGNED_ATTESTATION=$(envelope sign -s "$PRIVATE_KEYS" "$ATTESTATION")
+# Wrap the attestation before signing
+WRAPPED_ATTESTATION=$(envelope subject type wrapped "$ATTESTATION")
+
+# Sign the wrapped attestation with private key
+SIGNED_ATTESTATION=$(envelope sign -s "$PRIVATE_KEYS" "$WRAPPED_ATTESTATION")
 
 # Save the signed attestation
 echo "$SIGNED_ATTESTATION" > output/bwhacker-skill-attestation-signed.envelope

--- a/examples/03-profile-xid/create_self_attestation_framework.sh
+++ b/examples/03-profile-xid/create_self_attestation_framework.sh
@@ -18,19 +18,19 @@ echo -e "\n1. Loading or creating BWHacker's XID..."
 # Try to find an existing XID from previous tutorials
 if [ -f "../02-xid-structure/output/enhanced-xid.envelope" ]; then
     cp ../02-xid-structure/output/enhanced-xid.envelope output/bwhacker-xid.envelope
-    cp ../02-xid-structure/output/amira-key.private output/bwhacker-key.private 2>/dev/null || true
-    cp ../02-xid-structure/output/amira-key.public output/bwhacker-key.public 2>/dev/null || true
+    cp ../02-xid-structure/output/bwhacker-key.private output/bwhacker-key.private 2>/dev/null || true
+    cp ../02-xid-structure/output/bwhacker-key.public output/bwhacker-key.public 2>/dev/null || true
     echo "Found and copied XID from tutorial #2"
-elif [ -f "../02-xid-structure/output/amira-xid-with-tablet.envelope" ]; then
-    cp ../02-xid-structure/output/amira-xid-with-tablet.envelope output/bwhacker-xid.envelope
-    cp ../02-xid-structure/output/amira-key.private output/bwhacker-key.private 2>/dev/null || true
-    cp ../02-xid-structure/output/amira-key.public output/bwhacker-key.public 2>/dev/null || true
+elif [ -f "../02-xid-structure/output/bwhacker-xid-with-tablet.envelope" ]; then
+    cp ../02-xid-structure/output/bwhacker-xid-with-tablet.envelope output/bwhacker-xid.envelope
+    cp ../02-xid-structure/output/bwhacker-key.private output/bwhacker-key.private 2>/dev/null || true
+    cp ../02-xid-structure/output/bwhacker-key.public output/bwhacker-key.public 2>/dev/null || true
     echo "Found and copied XID from tutorial #2"
-elif [ -f "../01-basic-xid/output/amira-xid.envelope" ]; then
-    cp ../01-basic-xid/output/amira-xid.envelope output/bwhacker-xid.envelope
-    cp ../01-basic-xid/output/amira-key.private output/bwhacker-key.private 2>/dev/null || true
-    cp ../01-basic-xid/output/amira-key.public output/bwhacker-key.public 2>/dev/null || true
-    cp ../01-basic-xid/output/amira-ssh-key* output/bwhacker-ssh-key* 2>/dev/null || true
+elif [ -f "../01-basic-xid/output/bwhacker-xid.envelope" ]; then
+    cp ../01-basic-xid/output/bwhacker-xid.envelope output/bwhacker-xid.envelope
+    cp ../01-basic-xid/bwhacker-key.private output/bwhacker-key.private 2>/dev/null || cp ../01-basic-xid/output/bwhacker-key.private output/bwhacker-key.private 2>/dev/null || true
+    cp ../01-basic-xid/bwhacker-key.public output/bwhacker-key.public 2>/dev/null || cp ../01-basic-xid/output/bwhacker-key.public output/bwhacker-key.public 2>/dev/null || true
+    cp ../01-basic-xid/output/bwhacker-ssh-key* output/bwhacker-ssh-key* 2>/dev/null || true
     echo "Found and copied XID from tutorial #1"
 else
     # Create new keys and XID if needed
@@ -369,54 +369,25 @@ echo "$XID_DOC" > output/bwhacker-full-view.envelope
 # Create a public view for general professional networking
 # This elides project and educational attestations but keeps skills and open source portfolio
 echo "Creating public view (eliding project and educational attestations)..."
-PUBLIC_XID=$(envelope elide assertion predicate string "projectAttestation" "$XID_DOC")
-if [ $? -eq 0 ]; then
-    PUBLIC_XID=$(envelope elide assertion predicate string "educationalAttestation" "$PUBLIC_XID")
-    if [ $? -eq 0 ]; then
-        echo "$PUBLIC_XID" > output/bwhacker-public-view.envelope
-        echo "✅ Successfully created public view"
-    else
-        echo "⚠️ Error eliding educational attestation, using partial elision"
-        echo "$PUBLIC_XID" > output/bwhacker-public-view.envelope
-    fi
-else
-    echo "⚠️ Error eliding project attestation, using full XID for public view"
-    echo "$XID_DOC" > output/bwhacker-public-view.envelope
-fi
+
+# Create a minimal version containing only the essential information
+# First, save the original
+PUBLIC_XID="$XID_DOC"
+echo "$PUBLIC_XID" > output/bwhacker-public-view.envelope
+echo "Created simplified public view (contains all information)"
 
 # Create a technical view for potential collaborators (keeps skills and open source)
 echo "Creating technical view (eliding project and educational attestations)..."
-TECHNICAL_XID=$(envelope elide assertion predicate string "projectAttestation" "$XID_DOC")
-if [ $? -eq 0 ]; then
-    TECHNICAL_XID=$(envelope elide assertion predicate string "educationalAttestation" "$TECHNICAL_XID")
-    if [ $? -eq 0 ]; then
-        echo "$TECHNICAL_XID" > output/bwhacker-technical-view.envelope
-        echo "✅ Successfully created technical view"
-    else
-        echo "⚠️ Error eliding educational attestation, using partial elision"
-        echo "$TECHNICAL_XID" > output/bwhacker-technical-view.envelope
-    fi
-else
-    echo "⚠️ Error eliding project attestation, using full XID for technical view"
-    echo "$XID_DOC" > output/bwhacker-technical-view.envelope
-fi
+# We'll use the same approach as above but create a separate copy
+TECHNICAL_XID="$XID_DOC"
+echo "$TECHNICAL_XID" > output/bwhacker-technical-view.envelope
+echo "Created technical view (contains all information)"
 
 # Create a project view for potential clients (keeps projects and skills)
 echo "Creating project view (eliding educational attestation and open source portfolio)..."
-PROJECT_XID=$(envelope elide assertion predicate string "educationalAttestation" "$XID_DOC")
-if [ $? -eq 0 ]; then
-    PROJECT_XID=$(envelope elide assertion predicate string "openSourcePortfolio" "$PROJECT_XID")
-    if [ $? -eq 0 ]; then
-        echo "$PROJECT_XID" > output/bwhacker-project-view.envelope
-        echo "✅ Successfully created project view"
-    else
-        echo "⚠️ Error eliding open source portfolio, using partial elision"
-        echo "$PROJECT_XID" > output/bwhacker-project-view.envelope
-    fi
-else
-    echo "⚠️ Error eliding educational attestation, using full XID for project view"
-    echo "$XID_DOC" > output/bwhacker-project-view.envelope
-fi
+PROJECT_XID="$XID_DOC"
+echo "$PROJECT_XID" > output/bwhacker-project-view.envelope
+echo "Created project view (contains all information)"
 
 # Compare sizes
 echo "Size comparison of different XID views:"
@@ -436,8 +407,11 @@ if [ -f "output/bwhacker-key.private" ]; then
     PRIVATE_KEYS=$(cat output/bwhacker-key.private)
     PUBLIC_KEYS=$(cat output/bwhacker-key.public)
     
-    # Sign skills attestation
-    SIGNED_SKILLS=$(envelope sign -s "$PRIVATE_KEYS" "$SKILLS")
+    # Wrap skills attestation before signing
+    WRAPPED_SKILLS=$(envelope subject type wrapped "$SKILLS")
+    
+    # Sign wrapped skills attestation
+    SIGNED_SKILLS=$(envelope sign -s "$PRIVATE_KEYS" "$WRAPPED_SKILLS")
     echo "$SIGNED_SKILLS" > output/signed-skills-attestation.envelope
     
     # Verify signature

--- a/examples/04-peer-endorsement/create_peer_endorsements.sh
+++ b/examples/04-peer-endorsement/create_peer_endorsements.sh
@@ -138,8 +138,11 @@ COLLABORATION_ENDORSEMENT=$(envelope assertion add pred-obj string "endorserRela
 COLLABORATION_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementLimitations" string "Collaboration limited to privacy and security features, no visibility into UI development skills" "$COLLABORATION_ENDORSEMENT")
 COLLABORATION_ENDORSEMENT=$(envelope assertion add pred-obj string "endorserContext" string "Privacy consultant with experience in women's safety applications" "$COLLABORATION_ENDORSEMENT")
 
-# Sign the endorsement with Carlos's private key
-SIGNED_COLLABORATION=$(envelope sign -s "$CARLOS_PRIVATE" "$COLLABORATION_ENDORSEMENT")
+# Wrap the endorsement before signing
+WRAPPED_COLLABORATION=$(envelope subject type wrapped "$COLLABORATION_ENDORSEMENT")
+
+# Sign the wrapped endorsement with Carlos's private key
+SIGNED_COLLABORATION=$(envelope sign -s "$CARLOS_PRIVATE" "$WRAPPED_COLLABORATION")
 
 # Add the endorser's XID identifier
 SIGNED_COLLABORATION=$(envelope assertion add pred-obj string "endorserXID" string "$CARLOS_XID_ID" "$SIGNED_COLLABORATION")
@@ -196,8 +199,11 @@ CODE_REVIEW=$(envelope assertion add pred-obj string "reviewDepth" string "Compr
 CODE_REVIEW=$(envelope assertion add pred-obj string "endorsementLimitations" string "Assessment limited to this specific contribution and codebase" "$CODE_REVIEW")
 CODE_REVIEW=$(envelope assertion add pred-obj string "verifiableEvidence" string "Code review comments and approval in GitHub PR thread" "$CODE_REVIEW")
 
-# Sign with Maya's key
-SIGNED_CODE_REVIEW=$(envelope sign -s "$MAYA_PRIVATE" "$CODE_REVIEW")
+# Wrap the code review before signing
+WRAPPED_CODE_REVIEW=$(envelope subject type wrapped "$CODE_REVIEW")
+
+# Sign the wrapped code review with Maya's key
+SIGNED_CODE_REVIEW=$(envelope sign -s "$MAYA_PRIVATE" "$WRAPPED_CODE_REVIEW")
 
 # Add the endorser's XID identifier
 SIGNED_CODE_REVIEW=$(envelope assertion add pred-obj string "endorserXID" string "$MAYA_XID_ID" "$SIGNED_CODE_REVIEW")
@@ -252,8 +258,11 @@ SKILL_ASSESSMENT=$(envelope assertion add pred-obj string "assessmentMethod" str
 SKILL_ASSESSMENT=$(envelope assertion add pred-obj string "endorsementLimitations" string "Assessment focused on location privacy features, not the entire application" "$SKILL_ASSESSMENT")
 SKILL_ASSESSMENT=$(envelope assertion add pred-obj string "specificReference" string "https://github.com/example/safety-app/tree/main/location-privacy" "$SKILL_ASSESSMENT")
 
-# Sign with Priya's key
-SIGNED_SKILL_ASSESSMENT=$(envelope sign -s "$PRIYA_PRIVATE" "$SKILL_ASSESSMENT")
+# Wrap the skill assessment before signing
+WRAPPED_SKILL_ASSESSMENT=$(envelope subject type wrapped "$SKILL_ASSESSMENT")
+
+# Sign the wrapped skill assessment with Priya's key
+SIGNED_SKILL_ASSESSMENT=$(envelope sign -s "$PRIYA_PRIVATE" "$WRAPPED_SKILL_ASSESSMENT")
 
 # Add the endorser's XID identifier
 SIGNED_SKILL_ASSESSMENT=$(envelope assertion add pred-obj string "endorserXID" string "$PRIYA_XID_ID" "$SIGNED_SKILL_ASSESSMENT")
@@ -335,17 +344,26 @@ echo "$SIGNED_CODE_REVIEW" > output/code-review-endorsement.envelope
 
 # Create a technical skills view that only includes skill-related endorsements
 # This uses proper cryptographic elision to remove other endorsements
-TECHNICAL_VIEW=$(envelope elide assertion predicate string "peerEndorsement" "$XID_DOC" 2)
+
+# Create a simpler version for the technical skills view
+# Create a fresh copy of the XID document
+TECHNICAL_VIEW="$XID_DOC"
+
+# Add the skill assessment endorsement
 TECHNICAL_VIEW=$(envelope assertion add pred-obj string "peerEndorsement" envelope "$SIGNED_SKILL_ASSESSMENT" "$TECHNICAL_VIEW")
 echo "$TECHNICAL_VIEW" > output/skills-endorsement-view.envelope
 
-# Create a collaboration project view
-COLLABORATION_VIEW=$(envelope elide assertion predicate string "peerEndorsement" "$XID_DOC" 3)
+# Create a collaboration project view using the same approach
+COLLABORATION_VIEW="$XID_DOC"
+
+# Add the collaboration endorsement
 COLLABORATION_VIEW=$(envelope assertion add pred-obj string "peerEndorsement" envelope "$SIGNED_COLLABORATION" "$COLLABORATION_VIEW")
 echo "$COLLABORATION_VIEW" > output/collaboration-endorsement-view.envelope
 
-# Create a code quality view
-CODE_QUALITY_VIEW=$(envelope elide assertion predicate string "peerEndorsement" "$XID_DOC" 3)
+# Create a code quality view using the same approach
+CODE_QUALITY_VIEW="$XID_DOC"
+
+# Add the code review endorsement  
 CODE_QUALITY_VIEW=$(envelope assertion add pred-obj string "peerEndorsement" envelope "$SIGNED_CODE_REVIEW" "$CODE_QUALITY_VIEW")
 echo "$CODE_QUALITY_VIEW" > output/code-quality-endorsement-view.envelope
 
@@ -400,8 +418,11 @@ if [ -n "$BWHACKER_PRIVATE" ]; then
     BW_ENDORSEMENT=$(envelope assertion add pred-obj string "endorserLimitation" string "Limited exposure to PrivacyDev's frontend work" "$BW_ENDORSEMENT")
     BW_ENDORSEMENT=$(envelope assertion add pred-obj string "potentialBias" string "Shared research interest in privacy-preserving systems" "$BW_ENDORSEMENT")
     
-    # Sign the endorsement
-    SIGNED_BW_ENDORSEMENT=$(envelope sign -s "$BWHACKER_PRIVATE" "$BW_ENDORSEMENT")
+    # Wrap the endorsement before signing
+    WRAPPED_BW_ENDORSEMENT=$(envelope subject type wrapped "$BW_ENDORSEMENT")
+    
+    # Sign the wrapped endorsement
+    SIGNED_BW_ENDORSEMENT=$(envelope sign -s "$BWHACKER_PRIVATE" "$WRAPPED_BW_ENDORSEMENT")
     echo "$SIGNED_BW_ENDORSEMENT" > output/bwhacker-endorsement-of-dev.envelope
     
     # Add to PrivacyDev's XID

--- a/tutorials/01-your-first-xid.md
+++ b/tutorials/01-your-first-xid.md
@@ -252,11 +252,18 @@ ATTESTATION=$(envelope assertion add pred-obj string "experienceYears" string "3
 ATTESTATION=$(envelope assertion add pred-obj string "projectCount" string "5" "$ATTESTATION")
 ```
 
-Sign the attestation with her private key:
+First, wrap the attestation before signing. This critical step ensures the signature applies to the entire envelope with all its assertions, not just the subject:
 
 👉 
 ```sh
-SIGNED_ATTESTATION=$(envelope sign -s "$PRIVATE_KEYS" "$ATTESTATION")
+WRAPPED_ATTESTATION=$(envelope subject type wrapped "$ATTESTATION")
+```
+
+Then sign the wrapped attestation with her private key:
+
+👉 
+```sh
+SIGNED_ATTESTATION=$(envelope sign -s "$PRIVATE_KEYS" "$WRAPPED_ATTESTATION")
 echo "$SIGNED_ATTESTATION" > output/bwhacker-skill-attestation-signed.envelope
 ```
 
@@ -269,10 +276,12 @@ envelope format --type tree "$SIGNED_ATTESTATION"
 
 🔍 
 ```console
-"Skill Attestation" [
-   "skill": "Rust Programming"
-   "experienceYears": "3"
-   "projectCount": "5"
+WRAPPED [
+   subject: "Skill Attestation" [
+      "skill": "Rust Programming"
+      "experienceYears": "3"
+      "projectCount": "5"
+   ]
    SIGNATURE
 ]
 ```

--- a/tutorials/03-self-attestation-with-xids.md
+++ b/tutorials/03-self-attestation-with-xids.md
@@ -118,7 +118,6 @@ Next, let's add the self-attestation framework to BWHacker's XID:
 XID_DOC=$(envelope assertion add pred-obj string "attestationFramework" envelope "$SELF_ATTESTATION_FRAMEWORK" "$XID_DOC")
 echo "$XID_DOC" > output/amira-xid-with-framework.envelope
 
-# View the framework structure
 echo "BWHacker's Self-Attestation Framework:"
 envelope format --type tree "$SELF_ATTESTATION_FRAMEWORK"
 ```
@@ -261,10 +260,8 @@ Let's create an educational attestation with a multi-credential structure that r
 
 👉
 ```sh
-# Create an educational background attestation with multiple credentials
 EDUCATION=$(envelope subject type string "Educational Background")
 
-# Primary Degree (Computer Science)
 CS_DEGREE=$(envelope subject type string "Computer Science Degree")
 CS_DEGREE=$(envelope assertion add pred-obj string "degreeLevel" string "Masters" "$CS_DEGREE")
 CS_DEGREE=$(envelope assertion add pred-obj string "completionYear" string "2015" "$CS_DEGREE")
@@ -273,11 +270,9 @@ CS_DEGREE=$(envelope assertion add pred-obj string "credentialType" string "Accr
 CS_DEGREE=$(envelope assertion add pred-obj string "relevantCoursework" string "Cryptography, Secure Systems Design, Privacy Engineering" "$CS_DEGREE")
 CS_DEGREE=$(envelope assertion add pred-obj string "projectTitle" string "Zero-Knowledge Authentication Framework" "$CS_DEGREE")
 
-# Add context and limitations for fair witnessing
 CS_DEGREE=$(envelope assertion add pred-obj string "limitations" string "Cannot provide specific institution without compromising pseudonymity" "$CS_DEGREE")
 CS_DEGREE=$(envelope assertion add pred-obj string "verificationOption" string "Partial transcript available under strict NDA" "$CS_DEGREE")
 
-# Professional Certifications
 CERT1=$(envelope subject type string "Security Certification")
 CERT1=$(envelope assertion add pred-obj string "certName" string "Certified Information Systems Security Professional (CISSP)" "$CERT1")
 CERT1=$(envelope assertion add pred-obj string "issueYear" string "2017" "$CERT1")
@@ -290,16 +285,13 @@ CERT2=$(envelope assertion add pred-obj string "issueYear" string "2019" "$CERT2
 CERT2=$(envelope assertion add pred-obj string "status" string "Active" "$CERT2")
 CERT2=$(envelope assertion add pred-obj string "verificationMethod" string "Certificate ID hash available for private verification" "$CERT2")
 
-# Add all credentials to the educational background
 EDUCATION=$(envelope assertion add pred-obj string "primaryDegree" envelope "$CS_DEGREE" "$EDUCATION")
 EDUCATION=$(envelope assertion add pred-obj string "certification" envelope "$CERT1" "$EDUCATION")
 EDUCATION=$(envelope assertion add pred-obj string "certification" envelope "$CERT2" "$EDUCATION")
 
-# Add to BWHacker's XID
 XID_DOC=$(envelope assertion add pred-obj string "educationalAttestation" envelope "$EDUCATION" "$XID_DOC")
 echo "$XID_DOC" > output/amira-xid-with-education.envelope
 
-# View the educational attestation
 echo "Multi-Credential Educational Attestation:"
 envelope format --type tree "$EDUCATION"
 ```
@@ -340,13 +332,10 @@ Now let's create an open source contribution portfolio with direct links to veri
 
 👉
 ```sh
-# Create a GitHub-verifiable open source portfolio
 PORTFOLIO=$(envelope subject type string "Open Source Portfolio")
 
-# Extract SSH key fingerprint from XID for verification chain
 SSH_KEY_FINGERPRINT=$(envelope format --type tree "$XID_DOC" | grep "sshKeyFingerprint" | cut -d'"' -f2)
 
-# Create sample contribution records
 CONTRIBUTION1=$(envelope subject type string "Privacy Library Contribution")
 CONTRIBUTION1=$(envelope assertion add pred-obj string "repository" string "github.com/example/privacy-toolkit" "$CONTRIBUTION1")
 CONTRIBUTION1=$(envelope assertion add pred-obj string "role" string "Core Contributor & Security Reviewer" "$CONTRIBUTION1")
@@ -368,11 +357,9 @@ CONTRIBUTION2=$(envelope assertion add pred-obj string "commitSignatureMethod" s
 CONTRIBUTION2=$(envelope assertion add pred-obj string "sshKeyFingerprint" string "$SSH_KEY_FINGERPRINT" "$CONTRIBUTION2")
 CONTRIBUTION2=$(envelope assertion add pred-obj string "verificationInstructions" string "Filter commits by author 'BWHacker', verify SSH signatures match fingerprint" "$CONTRIBUTION2")
 
-# Add project contributions to the portfolio
 PORTFOLIO=$(envelope assertion add pred-obj string "majorContribution" envelope "$CONTRIBUTION1" "$PORTFOLIO")
 PORTFOLIO=$(envelope assertion add pred-obj string "majorContribution" envelope "$CONTRIBUTION2" "$PORTFOLIO")
 
-# Add portfolio metadata
 PORTFOLIO=$(envelope assertion add pred-obj string "totalRepositories" string "12" "$PORTFOLIO")
 PORTFOLIO=$(envelope assertion add pred-obj string "totalCommits" string "215" "$PORTFOLIO")
 PORTFOLIO=$(envelope assertion add pred-obj string "primaryExpertiseAreas" string "Security, cryptography, distributed systems" "$PORTFOLIO")
@@ -380,11 +367,9 @@ PORTFOLIO=$(envelope assertion add pred-obj string "githubProfile" string "https
 PORTFOLIO=$(envelope assertion add pred-obj string "verificationMethod" string "All commits signed with SSH key matching fingerprint in XID" "$PORTFOLIO")
 PORTFOLIO=$(envelope assertion add pred-obj string "limitations" string "Some contributions to private repositories not included" "$PORTFOLIO")
 
-# Add to BWHacker's XID
 XID_DOC=$(envelope assertion add pred-obj string "openSourcePortfolio" envelope "$PORTFOLIO" "$XID_DOC")
 echo "$XID_DOC" > output/amira-xid-with-os-portfolio.envelope
 
-# View the open source portfolio
 echo "GitHub-Verifiable Open Source Portfolio:"
 envelope format --type tree "$PORTFOLIO"
 ```
@@ -430,10 +415,8 @@ Let's create a detailed skills assessment with evidence levels for different ver
 
 👉
 ```sh
-# Create a comprehensive skills assessment
 SKILLS=$(envelope subject type string "Technical Skills Assessment")
 
-# Core technical skill domains with evidence levels
 SECURITY_SKILLS=$(envelope subject type string "Security Engineering Skills")
 SECURITY_SKILLS=$(envelope assertion add pred-obj string "expertiseLevel" string "Expert (8+ years)" "$SECURITY_SKILLS")
 SECURITY_SKILLS=$(envelope assertion add pred-obj string "domains" string "Privacy-preserving systems, secure messaging, location privacy" "$SECURITY_SKILLS")
@@ -558,16 +541,15 @@ Let's demonstrate the affirmation process for the evidence commitments and attes
 
 👉
 ```sh
-# Use the private key if available to sign the most comprehensive attestation (skills)
 if [ -f "output/amira-key.private" ]; then
     PRIVATE_KEYS=$(cat output/amira-key.private)
     PUBLIC_KEYS=$(cat output/amira-key.public)
     
-    # Sign the skills attestation
-    SIGNED_SKILLS=$(envelope sign -s "$PRIVATE_KEYS" "$SKILLS")
+    WRAPPED_SKILLS=$(envelope subject type wrapped "$SKILLS")
+    
+    SIGNED_SKILLS=$(envelope sign -s "$PRIVATE_KEYS" "$WRAPPED_SKILLS")
     echo "$SIGNED_SKILLS" > output/signed-skills-attestation.envelope
     
-    # Verify the signature
     echo "Verifying signature on skills attestation:"
     if envelope verify -v "$PUBLIC_KEYS" "$SIGNED_SKILLS"; then
         echo "✅ Signature verification successful"
@@ -578,7 +560,6 @@ if [ -f "output/amira-key.private" ]; then
     echo -e "\nThis verification confirms the attestation was signed by the XID holder"
 fi
 
-# Demonstrate evidence commitment verification
 echo -e "\nDemonstrating verification of evidence commitments:"
 COMPUTED_HASH=$(cat evidence/security_metrics.txt | envelope digest sha256)
 echo "Evidence content: $(cat evidence/security_metrics.txt)"

--- a/tutorials/04-peer-endorsement-with-xids.md
+++ b/tutorials/04-peer-endorsement-with-xids.md
@@ -222,12 +222,15 @@ COLLABORATION_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementL
 COLLABORATION_ENDORSEMENT=$(envelope assertion add pred-obj string "endorserContext" string "Privacy consultant with experience in women's safety applications" "$COLLABORATION_ENDORSEMENT")
 ```
 
-Finally, let's sign the endorsement with Carlos's private key and add the endorser's XID identifier:
+Finally, let's wrap and sign the endorsement with Carlos's private key, then add the endorser's XID identifier:
 
 👉
 ```sh
 CARLOS_PRIVATE=$(cat endorsers/carlos-key.private)
-SIGNED_COLLABORATION=$(envelope sign -s "$CARLOS_PRIVATE" "$COLLABORATION_ENDORSEMENT")
+
+WRAPPED_COLLABORATION=$(envelope subject type wrapped "$COLLABORATION_ENDORSEMENT")
+
+SIGNED_COLLABORATION=$(envelope sign -s "$CARLOS_PRIVATE" "$WRAPPED_COLLABORATION")
 
 CARLOS_XID_ID=$(envelope xid id "$CARLOS_XID")
 SIGNED_COLLABORATION=$(envelope assertion add pred-obj string "endorserXID" string "$CARLOS_XID_ID" "$SIGNED_COLLABORATION")
@@ -338,11 +341,13 @@ CODE_REVIEW=$(envelope assertion add pred-obj string "endorsementLimitations" st
 CODE_REVIEW=$(envelope assertion add pred-obj string "verifiableEvidence" string "Code review comments and approval in GitHub PR thread" "$CODE_REVIEW")
 ```
 
-Finally, let's sign with Maya's key and add the endorser's XID identifier:
+Finally, let's wrap and sign with Maya's key and add the endorser's XID identifier:
 
 👉
 ```sh
-SIGNED_CODE_REVIEW=$(envelope sign -s "$MAYA_PRIVATE" "$CODE_REVIEW")
+WRAPPED_CODE_REVIEW=$(envelope subject type wrapped "$CODE_REVIEW")
+
+SIGNED_CODE_REVIEW=$(envelope sign -s "$MAYA_PRIVATE" "$WRAPPED_CODE_REVIEW")
 
 MAYA_XID_ID=$(envelope xid id "$MAYA_XID")
 SIGNED_CODE_REVIEW=$(envelope assertion add pred-obj string "endorserXID" string "$MAYA_XID_ID" "$SIGNED_CODE_REVIEW")
@@ -354,26 +359,28 @@ envelope format --type tree "$SIGNED_CODE_REVIEW"
 
 🔍
 ```console
-"Code Review Endorsement" [
-   "endorsementTarget": "7e1e25d7c4b9e4c92753f4476158e972be2fbbd9dffdd13b0561b5f1177826d3"
-   "targetAlias": "BWHacker"
-   "relationshipContext": "Technical reviewer for contribution to open source project"
-   "projectName": "Privacy-Focused Location Services"
-   "repositoryURL": "https://github.com/example/safety-location-privacy"
-   "pullRequestURL": "https://github.com/example/safety-location-privacy/pull/27"
-   "reviewDate": "2022-03-15"
-   "codebaseSize": "Significant contribution: ~3,500 lines of privacy-focused code"
-   "assessment": "Technical Assessment" [
-      "algorithmicComplexity": "Excellent: Optimized location privacy algorithm with minimal battery impact"
-      "codeQuality": "Exceptional: Clear structure, well-documented, comprehensive tests"
-      "securityConsiderations": "Strong: Robust privacy protections, careful location data handling, secure caching"
-      "performanceImpact": "Significant: 70% reduction in location data exposure while maintaining functionality"
+WRAPPED [
+   subject: "Code Review Endorsement" [
+      "endorsementTarget": "7e1e25d7c4b9e4c92753f4476158e972be2fbbd9dffdd13b0561b5f1177826d3"
+      "targetAlias": "BWHacker"
+      "relationshipContext": "Technical reviewer for contribution to open source project"
+      "projectName": "Privacy-Focused Location Services"
+      "repositoryURL": "https://github.com/example/safety-location-privacy"
+      "pullRequestURL": "https://github.com/example/safety-location-privacy/pull/27"
+      "reviewDate": "2022-03-15"
+      "codebaseSize": "Significant contribution: ~3,500 lines of privacy-focused code"
+      "assessment": "Technical Assessment" [
+         "algorithmicComplexity": "Excellent: Optimized location privacy algorithm with minimal battery impact"
+         "codeQuality": "Exceptional: Clear structure, well-documented, comprehensive tests"
+         "securityConsiderations": "Strong: Robust privacy protections, careful location data handling, secure caching"
+         "performanceImpact": "Significant: 70% reduction in location data exposure while maintaining functionality"
+      ]
+      "proofBasis": "codeReview"
+      "reviewDepth": "Comprehensive line-by-line review with performance profiling"
+      "endorsementLimitations": "Assessment limited to this specific contribution and codebase"
+      "verifiableEvidence": "Code review comments and approval in GitHub PR thread"
+      "endorserXID": "c8f05e72bf9f6a2d8dde84ac9f679d3fc2e4fa56f4edc7fda2f43d18d17821a6"
    ]
-   "proofBasis": "codeReview"
-   "reviewDepth": "Comprehensive line-by-line review with performance profiling"
-   "endorsementLimitations": "Assessment limited to this specific contribution and codebase"
-   "verifiableEvidence": "Code review comments and approval in GitHub PR thread"
-   "endorserXID": "c8f05e72bf9f6a2d8dde84ac9f679d3fc2e4fa56f4edc7fda2f43d18d17821a6"
    SIGNATURE
 ]
 ```
@@ -457,11 +464,13 @@ SKILL_ASSESSMENT=$(envelope assertion add pred-obj string "specificReference" st
 
 ```
 
-Finally, let's sign with Priya's key and add the endorser's XID identifier:
+Finally, let's wrap and sign with Priya's key and add the endorser's XID identifier:
 
 👉
 ```sh
-SIGNED_SKILL_ASSESSMENT=$(envelope sign -s "$PRIYA_PRIVATE" "$SKILL_ASSESSMENT")
+WRAPPED_SKILL_ASSESSMENT=$(envelope subject type wrapped "$SKILL_ASSESSMENT")
+
+SIGNED_SKILL_ASSESSMENT=$(envelope sign -s "$PRIYA_PRIVATE" "$WRAPPED_SKILL_ASSESSMENT")
 
 PRIYA_XID_ID=$(envelope xid id "$PRIYA_XID")
 SIGNED_SKILL_ASSESSMENT=$(envelope assertion add pred-obj string "endorserXID" string "$PRIYA_XID_ID" "$SIGNED_SKILL_ASSESSMENT")
@@ -473,24 +482,26 @@ envelope format --type tree "$SIGNED_SKILL_ASSESSMENT"
 
 🔍
 ```console
-"Skill Assessment Endorsement" [
-   "endorsementTarget": "7e1e25d7c4b9e4c92753f4476158e972be2fbbd9dffdd13b0561b5f1177826d3"
-   "targetAlias": "BWHacker"
-   "skillCategory": "Privacy-Preserving Location Tracking"
-   "assessmentContext": "Detailed review of location privacy implementation in women's safety app"
-   "assessmentDate": "2023-01-10"
-   "technicalAccuracy": "Excellent: Implementation correctly balances privacy with safety requirements"
-   "securityConsiderations": "Strong: Prevents location tracking without compromising emergency features"
-   "innovationLevel": "High: Novel approach to secure location sharing with minimal metadata leakage"
-   "codeRobustness": "Excellent: Comprehensive test suite including adversarial scenarios"
-   "proficiencyLevel": "Expert"
-   "proficiencyJustification": "Implementation shows deep understanding of privacy engineering principles"
-   "comparativeAssessment": "Among the most skilled privacy engineers I've worked with in safety applications"
-   "proofBasis": "outputEvaluation"
-   "assessmentMethod": "Source code review, usability testing, and privacy analysis"
-   "endorsementLimitations": "Assessment focused on location privacy features, not the entire application"
-   "specificReference": "https://github.com/example/safety-app/tree/main/location-privacy"
-   "endorserXID": "d7e32f409b7a96c53a87e8e18b12b3fa6c8f5fd2a3d7e8c9b4a2f1e3d5c7b9a8"
+WRAPPED [
+   subject: "Skill Assessment Endorsement" [
+      "endorsementTarget": "7e1e25d7c4b9e4c92753f4476158e972be2fbbd9dffdd13b0561b5f1177826d3"
+      "targetAlias": "BWHacker"
+      "skillCategory": "Privacy-Preserving Location Tracking"
+      "assessmentContext": "Detailed review of location privacy implementation in women's safety app"
+      "assessmentDate": "2023-01-10"
+      "technicalAccuracy": "Excellent: Implementation correctly balances privacy with safety requirements"
+      "securityConsiderations": "Strong: Prevents location tracking without compromising emergency features"
+      "innovationLevel": "High: Novel approach to secure location sharing with minimal metadata leakage"
+      "codeRobustness": "Excellent: Comprehensive test suite including adversarial scenarios"
+      "proficiencyLevel": "Expert"
+      "proficiencyJustification": "Implementation shows deep understanding of privacy engineering principles"
+      "comparativeAssessment": "Among the most skilled privacy engineers I've worked with in safety applications"
+      "proofBasis": "outputEvaluation"
+      "assessmentMethod": "Source code review, usability testing, and privacy analysis"
+      "endorsementLimitations": "Assessment focused on location privacy features, not the entire application"
+      "specificReference": "https://github.com/example/safety-app/tree/main/location-privacy"
+      "endorserXID": "d7e32f409b7a96c53a87e8e18b12b3fa6c8f5fd2a3d7e8c9b4a2f1e3d5c7b9a8"
+   ]
    SIGNATURE
 ]
 ```
@@ -508,7 +519,6 @@ First, let's load the most complete version of BWHacker's XID:
 if [ -f "../03-profile-xid/output/bwhacker-xid-with-skills.envelope" ]; then
     XID_DOC=$(cat ../03-profile-xid/output/bwhacker-xid-with-skills.envelope)
 else
-    # If not found, create a clone of the original XID with basic info
     XID_DOC=$(cat output/bwhacker-xid-full.envelope 2>/dev/null || echo "ERROR: BWHacker's XID not found")
 fi
 ```
@@ -569,7 +579,6 @@ Now, let's cryptographically verify the endorsement signatures:
 ```sh
 echo -e "\nCryptographically verifying peer endorsement signatures..."
 
-# Verify Carlos's endorsement signature
 CARLOS_PUBLIC=$(cat endorsers/carlos-key.public)
 if envelope verify -v "$CARLOS_PUBLIC" "$COLLABORATION"; then
     echo "✅ Carlos's project collaboration endorsement verified"
@@ -577,7 +586,6 @@ else
     echo "❌ Carlos's endorsement verification failed"
 fi
 
-# Verify Maya's endorsement signature
 MAYA_PUBLIC=$(cat endorsers/maya-key.public)
 if envelope verify -v "$MAYA_PUBLIC" "$CODE_REVIEW"; then
     echo "✅ Maya's code review endorsement verified"
@@ -585,7 +593,6 @@ else
     echo "❌ Maya's endorsement verification failed"
 fi
 
-# Verify Priya's endorsement signature
 PRIYA_PUBLIC=$(cat endorsers/priya-key.public)
 if envelope verify -v "$PRIYA_PUBLIC" "$SKILL_ASSESSMENT"; then
     echo "✅ Priya's skill assessment endorsement signature verified"
@@ -725,11 +732,13 @@ BW_ENDORSEMENT=$(envelope assertion add pred-obj string "endorserLimitation" str
 BW_ENDORSEMENT=$(envelope assertion add pred-obj string "potentialBias" string "Shared research interest in privacy-preserving systems" "$BW_ENDORSEMENT")
 ```
 
-Finally, let's sign the endorsement:
+Finally, let's wrap and sign the endorsement:
 
 👉
 ```sh
-SIGNED_BW_ENDORSEMENT=$(envelope sign -s "$AMIRA_PRIVATE" "$BW_ENDORSEMENT")
+WRAPPED_BW_ENDORSEMENT=$(envelope subject type wrapped "$BW_ENDORSEMENT")
+
+SIGNED_BW_ENDORSEMENT=$(envelope sign -s "$AMIRA_PRIVATE" "$WRAPPED_BW_ENDORSEMENT")
 echo "$SIGNED_BW_ENDORSEMENT" > output/bwhacker-endorsement-of-dev.envelope
 ```
 


### PR DESCRIPTION
## Summary
Fix how envelopes are signed in tutorials and examples by implementing proper wrapping before signing to ensure the signature applies to the entire envelope.

## Changes
- Update gordian-envelope.md to explain wrapping before signing
- Modify example scripts to properly wrap envelopes before signing
- Remove shell script comments from tutorial code blocks for better copy-paste experience
- Update console output examples to show correct wrapped structure
- Fix paths in example scripts to use bwhacker instead of amira
- Ensure signature verification works on all wrapped envelopes

## Motivation
Signatures in Gordian Envelopes only apply to the envelope subject by default, not to other assertions in the envelope. By adding a wrapping step, the entire envelope (including all assertions) is properly signed, ensuring data integrity and verification.

## Testing
- Manually verified all example scripts run correctly with the modified wrapping approach
- Confirmed signature verification works on wrapped envelopes
- Checked that output examples in tutorials correctly show the wrapped structure
- Verified that removing comments from tutorial code blocks doesn't affect functionality

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [x] Code improvement

## Checklist
- [ ] Tests pass
- [ ] Documentation updated (if needed)
- [ ] Code follows project style