### PR TITLE
docs: fixed incorrect package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ _No prior knowledge of XIDs or Gordian Envelope is required._
 
 ### Quick-Start
 
-1. Install the `envelope` CLI tool: `cargo install envelope-cli`
+1. Install the `envelope` CLI tool: `cargo install bc-envelope-cli`
 2. Clone this repository: `git clone https://github.com/BlockchainCommons/XID-Quickstart.git`
 3. Optionally, review the core concepts from `concepts/README.md` until you're ready to get hands-on
 4. Navigate to the tutorials directory: `cd XID-Quickstart/tutorials`


### PR DESCRIPTION
updated README's `cargo install` script to reference proper package name for `envelope` CLI.

### Before
```sh
$ cargo install envelope-cli
    Updating crates.io index

error: could not find `envelope-cli` in registry `crates-io` with version `*`
```

### After 
```sh
$ cargo install bc-envelope-cli
  #################
  ###### logs ########

Installed package `bc-envelope-cli v0.21.0` (executable `envelope`)
```