### PR TITLE
Add tutorials 05-09 and improve T01-T04 consistency

### DIFF
--- a/tests/01-your-first-xid-TEST.sh
+++ b/tests/01-your-first-xid-TEST.sh
@@ -34,12 +34,8 @@ XID=$(envelope generate keypairs --signing ed25519 | \
     --generator encrypt \
     --sign inception)
 
-if [ $XID ]
-then
-  echo "✓ Created your XID: $XID_NAME"
-else
-  echo "❌ ERROR: XID creation"
-fiecho ""
+echo "✓ Created your XID: $XID_NAME"
+echo ""
 
 # View XID structure
 echo "Viewing XID structure:"
@@ -62,12 +58,7 @@ KEY_OBJECT=$(envelope extract object "$KEY_ASSERTION")
 PRIVATE_KEY_ASSERTION=$(envelope assertion find predicate known privateKey "$KEY_OBJECT")
 PRIVATE_KEY_DIGEST=$(envelope digest "$PRIVATE_KEY_ASSERTION")
 
-if [ $PRIVATE_KEY_DIGEST ]
-then
-  echo "✓ Found private key digest"
-else
-  echo "❌ Error: Private Key Retrieval"
-fi
+echo "✓ Found private key digest"
 
 # Elide the private key
 PUBLIC_XID=$(envelope elide removing "$PRIVATE_KEY_DIGEST" "$XID")
@@ -87,7 +78,7 @@ echo "Original XID digest: $ORIGINAL_DIGEST"
 echo "Public XID digest:   $PUBLIC_DIGEST"
 
 if [ "$ORIGINAL_DIGEST" = "$PUBLIC_DIGEST" ]; then
-    echo "✅ VERIFIED: Digests are identical - elision preserved the root hash\!"
+    echo "✅ VERIFIED: Digests are identical - elision preserved the root hash!"
 else
     echo "❌ ERROR: Digests differ"
     exit 1

--- a/tests/05-fair-witness-attestations-TEST.sh
+++ b/tests/05-fair-witness-attestations-TEST.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+#
+# Tutorial 05: Fair Witness Attestations - Test Script
+#
+# Tests all commands from Tutorial 05, verifying:
+# - Fair witness attestation creation (specific, verifiable claims)
+# - Detached attestation structure
+# - Attestation verification
+# - Attestation lifecycle (superseding and retraction patterns)
+#
+# Usage: bash tests/05-fair-witness-attestations-TEST.sh
+
+set -euo pipefail
+
+echo "========================================"
+echo "Tutorial 05: Fair Witness Attestations"
+echo "========================================"
+echo ""
+
+# Create output directory
+OUTPUT_DIR="output/xid-tutorial05-$(date +%Y%m%d%H%M%S)"
+mkdir -p "$OUTPUT_DIR"
+
+echo "=== Part I: Environment Setup ==="
+echo ""
+
+echo "Step 1: Create XID and attestation keys..."
+
+# Create Amira's XID with provenance tracking
+XID=$(envelope generate keypairs --signing ed25519 | \
+    envelope xid new --nickname "BRadvoc8" --generator include --sign inception)
+
+UNWRAPPED_XID=$(envelope extract wrapped "$XID")
+XID_ID=$(envelope xid id "$UNWRAPPED_XID")
+
+# Generate separate attestation signing keys (best practice)
+ATTESTATION_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+ATTESTATION_PUBKEYS=$(envelope generate pubkeys "$ATTESTATION_PRVKEYS")
+
+echo "✅ Created XID: $XID_ID"
+echo "✅ Generated attestation keys (separate from XID inception key)"
+echo ""
+
+echo "Step 2: Register attestation key in XID..."
+
+# Test password for encryption
+PASSWORD="test-password-123"
+
+# Add attestation keypair to XID (private key encrypted like inception key)
+XID=$(envelope xid key add \
+    --nickname "attestation-key" \
+    --allow sign \
+    --private encrypt \
+    --encrypt-password "$PASSWORD" \
+    "$ATTESTATION_PRVKEYS" \
+    "$XID")
+
+# Advance provenance to record the key addition
+XID=$(envelope xid provenance next "$XID")
+
+# Verify key was added with encrypted private key
+if envelope format "$XID" | grep -q "attestation-key"; then
+    echo "✅ Attestation key registered in XID"
+else
+    echo "❌ Failed to register attestation key"
+    exit 1
+fi
+
+# Verify private key is encrypted (ENCRYPTED appears before nickname in format output)
+if envelope format "$XID" | grep -B10 "attestation-key" | grep -q "ENCRYPTED"; then
+    echo "✅ Attestation private key is encrypted"
+else
+    echo "⚠️ Could not verify private key encryption"
+fi
+
+# Verify provenance advanced
+PROV_MARK=$(envelope xid provenance get "$XID")
+if provenance validate "$PROV_MARK" >/dev/null 2>&1; then
+    echo "✅ Provenance advanced and valid"
+else
+    echo "⚠️ Provenance mark present (validation warning expected for fresh XID)"
+fi
+echo ""
+
+echo "=== Part II: Creating Fair Witness Attestations ==="
+echo ""
+
+echo "Step 3: Create Galaxy Project attestation..."
+
+# Create the claim (specific, verifiable)
+CLAIM=$(envelope subject type string \
+  "I contributed mass spec visualization code to galaxyproject/galaxy (PR #12847, merged 2024)")
+
+# Add attestation metadata
+ATTESTATION=$(envelope assertion add pred-obj known isA string "SelfAttestation" "$CLAIM")
+ATTESTATION=$(envelope assertion add pred-obj string "attestedBy" string "$XID_ID" "$ATTESTATION")
+ATTESTATION=$(envelope assertion add pred-obj string "attestedOn" date "2026-01-21T00:00:00Z" "$ATTESTATION")
+ATTESTATION=$(envelope assertion add pred-obj string "verifiableAt" string "https://github.com/galaxyproject/galaxy/pull/12847" "$ATTESTATION")
+
+# Sign the attestation
+ATTESTATION_SIGNED=$(envelope sign --signer "$ATTESTATION_PRVKEYS" "$ATTESTATION")
+
+echo "✅ Created Galaxy Project attestation (fair witness: specific, verifiable)"
+echo ""
+echo "Attestation structure:"
+envelope format "$ATTESTATION_SIGNED" | head -12
+echo ""
+
+echo "Step 4: Verify the attestation..."
+
+if envelope verify --verifier "$ATTESTATION_PUBKEYS" "$ATTESTATION_SIGNED"; then
+    echo "✅ Signature verified"
+else
+    echo "❌ Signature verification failed"
+    exit 1
+fi
+echo ""
+
+echo "=== Part III: Understanding Verification ==="
+echo ""
+
+echo "What verification proves:"
+echo "  ✓ BRadvoc8's key signed this content"
+echo "  ✓ Content has not been modified"
+echo ""
+echo "What verification does NOT prove:"
+echo "  ✗ The claim is actually true"
+echo "  ✗ BRadvoc8 actually made the contribution"
+echo ""
+echo "The 'verifiableAt' field points to evidence verifiers can check independently."
+echo ""
+
+echo "=== Part IV: Attestation Lifecycle ==="
+echo ""
+
+echo "Step 5: Supersede an attestation..."
+
+# Create an updated attestation (new accomplishments)
+UPDATED_CLAIM=$(envelope subject type string \
+  "I contributed mass spec visualization code to galaxyproject/galaxy (PRs #12847, #13102, #13445, merged 2024-2028)")
+
+UPDATED_ATTESTATION=$(envelope assertion add pred-obj known isA string "SelfAttestation" "$UPDATED_CLAIM")
+UPDATED_ATTESTATION=$(envelope assertion add pred-obj string "attestedBy" string "$XID_ID" "$UPDATED_ATTESTATION")
+UPDATED_ATTESTATION=$(envelope assertion add pred-obj string "attestedOn" date "2028-01-15T00:00:00Z" "$UPDATED_ATTESTATION")
+UPDATED_ATTESTATION=$(envelope assertion add pred-obj string "verifiableAt" string "https://github.com/galaxyproject/galaxy/pulls?q=author:BRadvoc8" "$UPDATED_ATTESTATION")
+
+# Reference the original attestation being superseded
+ORIGINAL_DIGEST=$(envelope digest "$ATTESTATION_SIGNED")
+UPDATED_ATTESTATION=$(envelope assertion add pred-obj string "supersedes" string "$ORIGINAL_DIGEST" "$UPDATED_ATTESTATION")
+
+# Sign
+UPDATED_ATTESTATION=$(envelope sign --signer "$ATTESTATION_PRVKEYS" "$UPDATED_ATTESTATION")
+
+echo "✅ Created updated attestation that supersedes original"
+echo ""
+echo "Updated attestation structure:"
+envelope format "$UPDATED_ATTESTATION" | head -12
+echo ""
+
+# Verify updated attestation
+if envelope verify --verifier "$ATTESTATION_PUBKEYS" "$UPDATED_ATTESTATION"; then
+    echo "✅ Updated attestation signature verified"
+else
+    echo "❌ Updated attestation signature failed"
+    exit 1
+fi
+
+# Verify supersedes field is present
+if envelope format "$UPDATED_ATTESTATION" | grep -q "supersedes"; then
+    echo "✅ Supersedes reference present (links to original digest)"
+else
+    echo "❌ Supersedes reference missing"
+    exit 1
+fi
+echo ""
+
+echo "Step 6: Create a retraction..."
+
+RETRACTION=$(envelope subject type string "RETRACTED: [original claim text]")
+RETRACTION=$(envelope assertion add pred-obj known isA string "Retraction" "$RETRACTION")
+RETRACTION=$(envelope assertion add pred-obj string "retracts" string "$ORIGINAL_DIGEST" "$RETRACTION")
+RETRACTION=$(envelope assertion add pred-obj string "reason" string "Claim was overstated" "$RETRACTION")
+RETRACTION=$(envelope sign --signer "$ATTESTATION_PRVKEYS" "$RETRACTION")
+
+echo "✅ Created retraction attestation"
+echo ""
+echo "Retraction structure:"
+envelope format "$RETRACTION" | head -10
+echo ""
+
+# Verify retraction signature
+if envelope verify --verifier "$ATTESTATION_PUBKEYS" "$RETRACTION"; then
+    echo "✅ Retraction signature verified"
+else
+    echo "❌ Retraction signature failed"
+    exit 1
+fi
+echo ""
+
+echo "=== Part V: Wrap-Up ==="
+echo ""
+
+# Save artifacts
+echo "$ATTESTATION_SIGNED" > "$OUTPUT_DIR/attestation-galaxy.envelope"
+echo "$UPDATED_ATTESTATION" > "$OUTPUT_DIR/attestation-galaxy-updated.envelope"
+echo "$RETRACTION" > "$OUTPUT_DIR/attestation-retraction.envelope"
+echo "$XID" > "$OUTPUT_DIR/BRadvoc8-xid.envelope"
+
+echo "Saved files to $OUTPUT_DIR:"
+ls -la "$OUTPUT_DIR"
+echo ""
+
+echo "========================================"
+echo "Tutorial 05 Test: ALL PASSED ✅"
+echo "========================================"
+echo ""
+echo "Summary:"
+echo "  - Created fair witness attestation (specific, verifiable claim)"
+echo "  - Registered attestation key in XID (with encrypted private key)"
+echo "  - Used detached attestation pattern (separate from XIDDoc)"
+echo "  - Included verifiableAt URL for evidence checking"
+echo "  - Verified attestation signature"
+echo "  - Demonstrated superseding pattern (updated attestation)"
+echo "  - Demonstrated retraction pattern"
+echo ""
+echo "Fair Witness Principle:"
+echo "  Strong: 'I contributed to Galaxy Project (PR #12847)'"
+echo "  Weak:   'I have 8 years of security experience'"
+echo ""
+echo "Attestation Lifecycle:"
+echo "  - Supersede: Create new attestation with 'supersedes' field"
+echo "  - Retract: Create retraction with 'retracts' field + reason"
+echo ""

--- a/tests/06-managing-sensitive-claims-TEST.sh
+++ b/tests/06-managing-sensitive-claims-TEST.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+#
+# Tutorial 06: Managing Sensitive Claims - Test Script
+#
+# Tests all commands from Tutorial 06, verifying:
+# - Correlation risk concepts
+# - Elided commitment creation
+# - Inclusion proof verification
+# - Full attestation reveal and verification
+#
+# Usage: bash tests/06-managing-sensitive-claims-TEST.sh
+
+set -euo pipefail
+
+echo "========================================"
+echo "Tutorial 06: Managing Sensitive Claims"
+echo "========================================"
+echo ""
+
+# Create output directory
+OUTPUT_DIR="output/xid-tutorial06-$(date +%Y%m%d%H%M%S)"
+mkdir -p "$OUTPUT_DIR"
+
+echo "=== Part I: Environment Setup ==="
+echo ""
+
+echo "Step 1: Create XID and attestation keys..."
+
+# Create Amira's XID
+XID=$(envelope generate keypairs --signing ed25519 | \
+    envelope xid new --nickname "BRadvoc8" --generator include --sign inception)
+
+UNWRAPPED_XID=$(envelope extract wrapped "$XID")
+XID_ID=$(envelope xid id "$UNWRAPPED_XID")
+
+# Attestation keys
+ATTESTATION_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+ATTESTATION_PUBKEYS=$(envelope generate pubkeys "$ATTESTATION_PRVKEYS")
+
+echo "✅ Created XID: $XID_ID"
+echo ""
+
+echo "=== Part II: Creating Sensitive Attestation ==="
+echo ""
+
+echo "Step 2: Create crypto audit attestation..."
+
+# Create the sensitive claim
+AUDIT_CLAIM=$(envelope subject type string \
+  "I audited cryptographic implementations for authentication systems (2023-2024)")
+
+AUDIT_CLAIM=$(envelope assertion add pred-obj known isA string "SelfAttestation" "$AUDIT_CLAIM")
+AUDIT_CLAIM=$(envelope assertion add pred-obj string "attestedBy" string "$XID_ID" "$AUDIT_CLAIM")
+AUDIT_CLAIM=$(envelope assertion add pred-obj string "attestedOn" date "2026-01-21T00:00:00Z" "$AUDIT_CLAIM")
+AUDIT_CLAIM=$(envelope assertion add pred-obj string "skillCategory" string "Security" "$AUDIT_CLAIM")
+
+echo "✅ Created sensitive attestation (crypto audit experience)"
+echo ""
+
+echo "Step 3: Sign the full attestation..."
+
+AUDIT_SIGNED=$(envelope sign --signer "$ATTESTATION_PRVKEYS" "$AUDIT_CLAIM")
+
+echo "✅ Full attestation signed"
+echo ""
+echo "Full attestation structure:"
+envelope format "$AUDIT_SIGNED" | head -10
+echo ""
+
+echo "=== Part III: Creating Elided Commitment ==="
+echo ""
+
+echo "Step 4: Create elided version..."
+
+AUDIT_DIGEST=$(envelope digest "$AUDIT_SIGNED")
+AUDIT_ELIDED=$(envelope elide removing "$AUDIT_DIGEST" "$AUDIT_SIGNED")
+
+echo "✅ Elided commitment created"
+echo "   Digest: ${AUDIT_DIGEST:0:40}..."
+echo ""
+
+echo "Step 5: Verify digests match (inclusion proof foundation)..."
+
+FULL_DIGEST=$(envelope digest "$AUDIT_SIGNED")
+ELIDED_DIGEST=$(envelope digest "$AUDIT_ELIDED")
+
+echo "   Full attestation digest:  ${FULL_DIGEST:0:40}..."
+echo "   Elided version digest:    ${ELIDED_DIGEST:0:40}..."
+
+if [ "$FULL_DIGEST" = "$ELIDED_DIGEST" ]; then
+    echo "✅ Digests match - inclusion proof possible"
+else
+    echo "❌ Digests don't match - this should not happen"
+    exit 1
+fi
+echo ""
+
+echo "Step 6: Show what elided version looks like..."
+
+echo "   Elided format:"
+envelope format "$AUDIT_ELIDED"
+echo ""
+echo "   (Content hidden, but cryptographic identity preserved)"
+echo ""
+
+echo "=== Part IV: Simulating Reveal to DevReviewer ==="
+echo ""
+
+echo "Step 7: DevReviewer receives full attestation..."
+echo "   (Amira sends AUDIT_SIGNED to DevReviewer)"
+echo ""
+
+echo "Step 8: DevReviewer verifies inclusion proof..."
+
+# DevReviewer computes digest of received attestation
+RECEIVED_DIGEST=$(envelope digest "$AUDIT_SIGNED")
+
+if [ "$RECEIVED_DIGEST" = "$ELIDED_DIGEST" ]; then
+    echo "✅ Inclusion proof valid: matches public commitment"
+else
+    echo "❌ Does not match commitment"
+    exit 1
+fi
+echo ""
+
+echo "Step 9: DevReviewer verifies signature..."
+
+if envelope verify --verifier "$ATTESTATION_PUBKEYS" "$AUDIT_SIGNED"; then
+    echo "✅ Signature valid"
+else
+    echo "❌ Signature verification failed"
+    exit 1
+fi
+echo ""
+
+echo "=== Part V: Demonstrating Elided Limitations ==="
+echo ""
+
+echo "Step 10: Show that elided version alone proves nothing about content..."
+
+echo "   Elided version format: $(envelope format "$AUDIT_ELIDED")"
+echo "   (No content to read, no signature to verify against content)"
+echo ""
+
+echo "Step 11: Try to verify elided version (should fail)..."
+
+if envelope verify --verifier "$ATTESTATION_PUBKEYS" "$AUDIT_ELIDED" 2>/dev/null; then
+    echo "❌ Elided version should NOT have verified"
+    exit 1
+else
+    echo "✅ Verification correctly failed - no signature in elided version"
+fi
+echo ""
+echo "   The elided version proves EXISTENCE and TIMING"
+echo "   The full version proves CONTENT and AUTHENTICITY"
+echo ""
+
+echo "=== Part VI: Wrap-Up ==="
+echo ""
+
+# Save artifacts
+echo "$AUDIT_SIGNED" > "$OUTPUT_DIR/audit-attestation-FULL.envelope"
+echo "$AUDIT_ELIDED" > "$OUTPUT_DIR/audit-attestation-ELIDED.envelope"
+echo "$AUDIT_DIGEST" > "$OUTPUT_DIR/audit-digest.txt"
+echo "$XID" > "$OUTPUT_DIR/BRadvoc8-xid.envelope"
+echo "$ATTESTATION_PRVKEYS" > "$OUTPUT_DIR/attestation-prvkeys.envelope"
+
+echo "Saved files to $OUTPUT_DIR:"
+ls -la "$OUTPUT_DIR"
+echo ""
+
+echo "========================================"
+echo "Tutorial 06 Test: ALL PASSED ✅"
+echo "========================================"
+echo ""
+echo "Summary:"
+echo "  - Created sensitive attestation (crypto audit)"
+echo "  - Created elided commitment (safe to share publicly)"
+echo "  - Verified inclusion proof (digests match)"
+echo "  - Simulated reveal to DevReviewer"
+echo "  - Verified signature on full attestation"
+echo ""
+echo "Three Disclosure Approaches:"
+echo "  1. Omit entirely - never publish"
+echo "  2. Commit elided - prove timing, reveal later"
+echo "  3. Encrypt for recipient - direct private sharing"
+echo ""
+echo "Correlation Risk Reminder:"
+echo "  Each claim narrows your anonymity set."
+echo "  Combined claims can uniquely identify you."
+echo ""

--- a/tests/07-encrypted-sharing-TEST.sh
+++ b/tests/07-encrypted-sharing-TEST.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+#
+# Tutorial 07: Encrypted Sharing - Test Script
+#
+# Tests all commands from Tutorial 07, verifying:
+# - Sensitive attestation creation (CivilTrust)
+# - Encryption for specific recipient (DevReviewer)
+# - Decryption and verification
+# - Failed decryption by unauthorized party
+#
+# Usage: bash tests/07-encrypted-sharing-TEST.sh
+
+set -euo pipefail
+
+echo "========================================"
+echo "Tutorial 07: Encrypted Sharing"
+echo "========================================"
+echo ""
+
+# Create output directory
+OUTPUT_DIR="output/xid-tutorial07-$(date +%Y%m%d%H%M%S)"
+mkdir -p "$OUTPUT_DIR"
+
+echo "=== Part I: Setting Up for Encryption ==="
+echo ""
+
+echo "Step 1: Establish Amira's identity..."
+
+# Create Amira's XID
+XID=$(envelope generate keypairs --signing ed25519 | \
+    envelope xid new --nickname "BRadvoc8" --generator include --sign inception)
+
+UNWRAPPED_XID=$(envelope extract wrapped "$XID")
+XID_ID=$(envelope xid id "$UNWRAPPED_XID")
+
+# Attestation signing keys
+ATTESTATION_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+ATTESTATION_PUBKEYS=$(envelope generate pubkeys "$ATTESTATION_PRVKEYS")
+
+echo "✅ Created Amira's XID: $XID_ID"
+echo ""
+
+echo "Step 2: Create DevReviewer's keys (recipient)..."
+
+# DevReviewer generates keys for receiving encrypted data
+DEVREVIEWER_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+DEVREVIEWER_PUBKEYS=$(envelope generate pubkeys "$DEVREVIEWER_PRVKEYS")
+
+echo "✅ DevReviewer's keys created for receiving encrypted data"
+echo ""
+
+echo "=== Part II: Creating the Sensitive Attestation ==="
+echo ""
+
+echo "Step 3: Create CivilTrust attestation..."
+
+# The sensitive claim (too dangerous for any public trace)
+CIVILTRUST_CLAIM=$(envelope subject type string \
+  "I designed the authentication system for CivilTrust human rights documentation platform (2024)")
+
+# Add attestation metadata
+CIVILTRUST_ATTESTATION=$(envelope assertion add pred-obj known isA string "SelfAttestation" "$CIVILTRUST_CLAIM")
+CIVILTRUST_ATTESTATION=$(envelope assertion add pred-obj string "attestedBy" string "$XID_ID" "$CIVILTRUST_ATTESTATION")
+CIVILTRUST_ATTESTATION=$(envelope assertion add pred-obj string "attestedOn" date "2026-01-21T00:00:00Z" "$CIVILTRUST_ATTESTATION")
+CIVILTRUST_ATTESTATION=$(envelope assertion add pred-obj string "privacyRisk" string "Links to legal identity via contributor list" "$CIVILTRUST_ATTESTATION")
+
+# Sign first (proves authenticity)
+CIVILTRUST_SIGNED=$(envelope sign --signer "$ATTESTATION_PRVKEYS" "$CIVILTRUST_ATTESTATION")
+
+echo "✅ Created CivilTrust attestation (before encryption)"
+echo ""
+echo "Attestation structure:"
+envelope format "$CIVILTRUST_SIGNED" | head -10
+echo ""
+
+echo "Step 4: Encrypt for DevReviewer..."
+
+CIVILTRUST_ENCRYPTED=$(envelope encrypt --recipient "$DEVREVIEWER_PUBKEYS" "$CIVILTRUST_SIGNED")
+
+echo "✅ Encrypted attestation for DevReviewer"
+echo ""
+echo "Encrypted format (content completely hidden):"
+envelope format "$CIVILTRUST_ENCRYPTED"
+echo ""
+
+echo "=== Part III: DevReviewer Receives and Verifies ==="
+echo ""
+
+echo "Step 5: DevReviewer decrypts..."
+
+CIVILTRUST_DECRYPTED=$(envelope decrypt --recipient "$DEVREVIEWER_PRVKEYS" "$CIVILTRUST_ENCRYPTED")
+
+echo "DevReviewer sees after decryption:"
+envelope format "$CIVILTRUST_DECRYPTED" | head -10
+echo ""
+
+echo "Step 6: DevReviewer verifies the signature..."
+
+if envelope verify --verifier "$ATTESTATION_PUBKEYS" "$CIVILTRUST_DECRYPTED"; then
+    echo "✅ DevReviewer verified the decrypted attestation"
+else
+    echo "❌ Verification failed"
+    exit 1
+fi
+echo ""
+
+echo "Step 7: Test decryption failure (Charlie intercepts)..."
+
+# Charlie generates his own keys
+CHARLIE_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+
+# Charlie tries to decrypt - should fail
+if envelope decrypt --recipient "$CHARLIE_PRVKEYS" "$CIVILTRUST_ENCRYPTED" 2>/dev/null; then
+    echo "❌ Charlie should NOT have been able to decrypt"
+    exit 1
+else
+    echo "✅ Charlie's decryption correctly failed (no matching recipient)"
+fi
+echo ""
+
+echo "=== Part IV: Wrap-Up ==="
+echo ""
+
+# Save artifacts
+echo "$CIVILTRUST_ENCRYPTED" > "$OUTPUT_DIR/civiltrust-for-devreviewer.envelope"
+echo "$XID" > "$OUTPUT_DIR/BRadvoc8-xid.envelope"
+echo "$ATTESTATION_PRVKEYS" > "$OUTPUT_DIR/attestation-prvkeys.envelope"
+
+echo "Saved files to $OUTPUT_DIR:"
+ls -la "$OUTPUT_DIR"
+echo ""
+
+echo "========================================"
+echo "Tutorial 07 Test: ALL PASSED ✅"
+echo "========================================"
+echo ""
+echo "Summary:"
+echo "  - Created CivilTrust attestation (too sensitive for public trace)"
+echo "  - Encrypted for DevReviewer specifically"
+echo "  - DevReviewer successfully decrypted and verified"
+echo "  - Charlie's decryption correctly failed"
+echo ""
+echo "Disclosure Approaches Summary:"
+echo "  - T05: Public attestation (Galaxy Project - already public)"
+echo "  - T06: Commit elided (crypto audit - prove timing later)"
+echo "  - T07: Encrypt for recipient (CivilTrust - no public trace)"
+echo ""

--- a/tests/08-peer-endorsements-TEST.sh
+++ b/tests/08-peer-endorsements-TEST.sh
@@ -1,0 +1,293 @@
+#!/bin/bash
+#
+# Tutorial 08: Peer Endorsements - Test Script
+#
+# Tests all commands from Tutorial 08, verifying:
+# - Personal endorsement creation (Charlene)
+# - Technical endorsement creation (DevReviewer)
+# - Collaboration endorsement creation (SecurityMaintainer)
+# - Endorsement verification chain
+# - Web of trust concepts
+#
+# Usage: bash tests/08-peer-endorsements-TEST.sh
+
+set -euo pipefail
+
+echo "========================================"
+echo "Tutorial 08: Peer Endorsements"
+echo "========================================"
+echo ""
+
+# Create output directory
+OUTPUT_DIR="output/xid-tutorial08-$(date +%Y%m%d%H%M%S)"
+mkdir -p "$OUTPUT_DIR"
+
+echo "=== Part I: Personal Endorsement from Charlene ==="
+echo ""
+
+echo "Step 1: Set up environment..."
+
+# Create Amira's XID using the piped keypairs pattern (with provenance for later update)
+XID=$(envelope generate keypairs --signing ed25519 | \
+    envelope xid new --nickname "BRadvoc8" --generator include --sign inception)
+
+UNWRAPPED_XID=$(envelope extract wrapped "$XID")
+XID_ID=$(envelope xid id "$UNWRAPPED_XID")
+
+echo "✅ Created Amira's XID: $XID_ID"
+echo ""
+
+echo "Step 2: Create Charlene's identity..."
+
+CHARLENE_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+CHARLENE_PUBKEYS=$(envelope generate pubkeys "$CHARLENE_PRVKEYS")
+
+CHARLENE_XID=$(envelope xid new --nickname "Charlene" "$CHARLENE_PUBKEYS")
+CHARLENE_XID_ID=$(envelope xid id "$CHARLENE_XID")
+
+echo "✅ Created Charlene's XID: $CHARLENE_XID_ID"
+echo ""
+
+echo "Step 3: Charlene creates her endorsement..."
+
+# Create the endorsement subject
+ENDORSEMENT=$(envelope subject type string "BRadvoc8 is a thoughtful and committed contributor to privacy work that protects vulnerable communities")
+
+# Add endorsement metadata
+ENDORSEMENT=$(envelope assertion add pred-obj known isA string "PeerEndorsement" "$ENDORSEMENT")
+ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedBy" string "Charlene" "$ENDORSEMENT")
+ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedOn" date "2026-01-21T00:00:00Z" "$ENDORSEMENT")
+ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementTarget" string "$XID_ID" "$ENDORSEMENT")
+
+# Add relationship context
+ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementContext" string "Personal friend, observed values and commitment over 2+ years" "$ENDORSEMENT")
+ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementScope" string "Character and values alignment, not technical skills" "$ENDORSEMENT")
+ENDORSEMENT=$(envelope assertion add pred-obj string "relationshipBasis" string "Friend who introduced BRadvoc8 to RISK network concept" "$ENDORSEMENT")
+
+# Charlene signs with her private key
+CHARLENE_ENDORSEMENT=$(envelope sign --signer "$CHARLENE_PRVKEYS" "$ENDORSEMENT")
+
+echo "$CHARLENE_ENDORSEMENT" > "$OUTPUT_DIR/endorsement-charlene.envelope"
+echo "✅ Created Charlene's character endorsement"
+envelope format "$CHARLENE_ENDORSEMENT" | head -12
+echo ""
+
+echo "Step 4: Verify Charlene's endorsement..."
+
+if envelope verify --verifier "$CHARLENE_PUBKEYS" "$CHARLENE_ENDORSEMENT"; then
+    echo "✅ Charlene's endorsement verified"
+else
+    echo "❌ Charlene's endorsement verification failed"
+    exit 1
+fi
+echo ""
+
+echo "=== Part II: Technical Endorsements ==="
+echo ""
+
+echo "Step 5: Create DevReviewer's endorsement..."
+
+REVIEWER_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+REVIEWER_PUBKEYS=$(envelope generate pubkeys "$REVIEWER_PRVKEYS")
+REVIEWER_XID=$(envelope xid new --nickname "DevReviewer" "$REVIEWER_PUBKEYS")
+REVIEWER_XID_ID=$(envelope xid id "$REVIEWER_XID")
+
+# Create technical endorsement
+TECH_ENDORSEMENT=$(envelope subject type string "BRadvoc8 writes secure, well-tested code with clear attention to privacy-preserving patterns")
+
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj known isA string "PeerEndorsement" "$TECH_ENDORSEMENT")
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedBy" string "DevReviewer" "$TECH_ENDORSEMENT")
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedOn" date "2026-01-21T00:00:00Z" "$TECH_ENDORSEMENT")
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementTarget" string "$XID_ID" "$TECH_ENDORSEMENT")
+
+# Technical context (DevReviewer relationship from T06-T07)
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementContext" string "Verified crypto audit experience, reviewed CivilTrust authentication design" "$TECH_ENDORSEMENT")
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementScope" string "Security architecture, cryptographic implementation, privacy patterns" "$TECH_ENDORSEMENT")
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj string "relationshipBasis" string "Security collaboration partner who verified credentials through commit-reveal and encrypted sharing" "$TECH_ENDORSEMENT")
+
+# Sign
+TECH_ENDORSEMENT_SIGNED=$(envelope sign --signer "$REVIEWER_PRVKEYS" "$TECH_ENDORSEMENT")
+
+echo "$TECH_ENDORSEMENT_SIGNED" > "$OUTPUT_DIR/endorsement-devreviewer.envelope"
+echo "✅ Created DevReviewer's technical endorsement"
+echo ""
+
+echo "Step 6: Create SecurityMaintainer's endorsement..."
+
+MAINTAINER_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+MAINTAINER_PUBKEYS=$(envelope generate pubkeys "$MAINTAINER_PRVKEYS")
+MAINTAINER_XID=$(envelope xid new --nickname "SecurityMaintainer" "$MAINTAINER_PUBKEYS")
+MAINTAINER_XID_ID=$(envelope xid id "$MAINTAINER_XID")
+
+# Create collaboration endorsement
+COLLAB_ENDORSEMENT=$(envelope subject type string "BRadvoc8 is a reliable contributor who delivers high-quality security enhancements and responds constructively to feedback")
+
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj known isA string "PeerEndorsement" "$COLLAB_ENDORSEMENT")
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedBy" string "SecurityMaintainer" "$COLLAB_ENDORSEMENT")
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedOn" date "2026-01-21T00:00:00Z" "$COLLAB_ENDORSEMENT")
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementTarget" string "$XID_ID" "$COLLAB_ENDORSEMENT")
+
+# Collaboration context
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementContext" string "Collaborated on 3 security features over 6 months" "$COLLAB_ENDORSEMENT")
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementScope" string "Technical skills, collaboration quality, communication" "$COLLAB_ENDORSEMENT")
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj string "relationshipBasis" string "Project maintainer who merged BRadvoc8's contributions" "$COLLAB_ENDORSEMENT")
+
+# Sign
+COLLAB_ENDORSEMENT_SIGNED=$(envelope sign --signer "$MAINTAINER_PRVKEYS" "$COLLAB_ENDORSEMENT")
+
+echo "$COLLAB_ENDORSEMENT_SIGNED" > "$OUTPUT_DIR/endorsement-maintainer.envelope"
+echo "✅ Created SecurityMaintainer's collaboration endorsement"
+echo ""
+
+echo "=== Part III: Verify Endorsement Chain ==="
+echo ""
+
+echo "Verifying all endorsements:"
+echo "============================"
+
+echo "1. Charlene (character):"
+if envelope verify --verifier "$CHARLENE_PUBKEYS" "$CHARLENE_ENDORSEMENT"; then
+    echo "   ✅ Signature valid"
+else
+    echo "   ❌ Verification failed"
+    exit 1
+fi
+
+echo "2. DevReviewer (technical):"
+if envelope verify --verifier "$REVIEWER_PUBKEYS" "$TECH_ENDORSEMENT_SIGNED"; then
+    echo "   ✅ Signature valid"
+else
+    echo "   ❌ Verification failed"
+    exit 1
+fi
+
+echo "3. SecurityMaintainer (collaboration):"
+if envelope verify --verifier "$MAINTAINER_PUBKEYS" "$COLLAB_ENDORSEMENT_SIGNED"; then
+    echo "   ✅ Signature valid"
+else
+    echo "   ❌ Verification failed"
+    exit 1
+fi
+
+echo "============================"
+echo "✅ All endorsements verified"
+echo ""
+
+echo "Step 7b: Test forgery detection..."
+
+# Attacker creates fake endorsement claiming to be from Charlene
+FAKE_ENDORSEMENT=$(envelope subject type string "BRadvoc8 is amazing at everything")
+FAKE_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedBy" string "Charlene" "$FAKE_ENDORSEMENT")
+
+# Attacker signs with their own key (not Charlene's)
+ATTACKER_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+FAKE_SIGNED=$(envelope sign --signer "$ATTACKER_PRVKEYS" "$FAKE_ENDORSEMENT")
+
+# Verification against Charlene's real public key should fail
+if envelope verify --verifier "$CHARLENE_PUBKEYS" "$FAKE_SIGNED" 2>/dev/null; then
+    echo "❌ Forgery should NOT have verified"
+    exit 1
+else
+    echo "✅ Forgery correctly rejected (signature doesn't match Charlene's key)"
+fi
+echo ""
+
+echo "Step 7c: Test elided endorsement with inclusion proof..."
+
+# Charlene fully elides endorsement before publishing (just shows ELIDED)
+ENDORSEMENT_DIGEST=$(envelope digest "$CHARLENE_ENDORSEMENT")
+ELIDED_ENDORSEMENT=$(envelope elide removing "$ENDORSEMENT_DIGEST" "$CHARLENE_ENDORSEMENT")
+
+# Verify full and elided have same digest (inclusion proof)
+FULL_DIGEST=$(envelope digest "$CHARLENE_ENDORSEMENT")
+ELIDED_DIGEST=$(envelope digest "$ELIDED_ENDORSEMENT")
+
+if [ "$FULL_DIGEST" = "$ELIDED_DIGEST" ]; then
+    echo "✅ Inclusion proof: full endorsement matches elided digest"
+else
+    echo "❌ Digests should match for inclusion proof"
+    exit 1
+fi
+
+# Verify signature on FULL version (not elided - elided has no content to verify)
+if envelope verify --verifier "$CHARLENE_PUBKEYS" "$CHARLENE_ENDORSEMENT"; then
+    echo "✅ Signature verifies on full endorsement"
+else
+    echo "❌ Signature should verify on full endorsement"
+    exit 1
+fi
+echo ""
+
+echo "=== Part IV: Web of Trust Summary ==="
+echo ""
+
+echo "Endorsement diversity:"
+echo "  | Endorser           | Type          | Relationship               |"
+echo "  |--------------------|---------------|----------------------------|"
+echo "  | Charlene           | Character     | Friend (2+ years)          |"
+echo "  | DevReviewer        | Technical     | Security collab (T06-T07)  |"
+echo "  | SecurityMaintainer | Collaboration | Maintainer (6 months)      |"
+echo ""
+
+echo "Trust multiplication:"
+echo "  1 endorsement         = Weak (could be a favor)"
+echo "  3 independent         = Moderate (pattern)"
+echo "  3 different contexts  = Strong (triangulated)"
+echo ""
+
+echo "=== Part VI: Updating Attestations After Endorsement ==="
+echo ""
+
+echo "Step 8: Upgrade attestation with endorsement reference..."
+
+# Create upgraded attestation referencing the SecurityMaintainer endorsement
+UPGRADED_CLAIM=$(envelope subject type string "I delivered security enhancements (endorsed by SecurityMaintainer, Jan 2026)")
+UPGRADED_ATTESTATION=$(envelope assertion add pred-obj known isA string "SelfAttestation" "$UPGRADED_CLAIM")
+UPGRADED_ATTESTATION=$(envelope assertion add pred-obj string "attestedBy" string "BRadvoc8" "$UPGRADED_ATTESTATION")
+UPGRADED_ATTESTATION=$(envelope assertion add pred-obj string "attestedOn" date "2026-01-21T00:00:00Z" "$UPGRADED_ATTESTATION")
+UPGRADED_ATTESTATION=$(envelope assertion add pred-obj string "validatedBy" string "$MAINTAINER_XID_ID" "$UPGRADED_ATTESTATION")
+
+# Sign with Amira's keys (need to extract from XID or use generated keys)
+AMIRA_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+UPGRADED_ATTESTATION=$(envelope sign --signer "$AMIRA_PRVKEYS" "$UPGRADED_ATTESTATION")
+
+echo "$UPGRADED_ATTESTATION" > "$OUTPUT_DIR/attestation-upgraded.envelope"
+echo "✅ Created upgraded attestation with endorsement reference"
+echo ""
+
+echo "Step 9: Advance provenance..."
+
+# Advance provenance to signal updated profile
+UPDATED_XID=$(envelope xid provenance next "$UNWRAPPED_XID")
+echo "✅ Provenance advanced to signal updated profile"
+echo ""
+
+echo "=== Part VII: Wrap-Up ==="
+echo ""
+
+# Save Amira's XID (private keys embedded, encrypted if using --private encrypt)
+echo "$XID" > "$OUTPUT_DIR/BRadvoc8-xid.envelope"
+
+# Save endorser XIDs
+echo "$CHARLENE_XID" > "$OUTPUT_DIR/charlene-xid.envelope"
+echo "$REVIEWER_XID" > "$OUTPUT_DIR/devreviewer-xid.envelope"
+echo "$MAINTAINER_XID" > "$OUTPUT_DIR/maintainer-xid.envelope"
+
+echo "Saved files to $OUTPUT_DIR:"
+ls -la "$OUTPUT_DIR"
+echo ""
+
+echo "========================================"
+echo "Tutorial 08 Test: ALL PASSED ✅"
+echo "========================================"
+echo ""
+echo "Summary:"
+echo "  - Created 3 endorsers with their own XIDs"
+echo "  - Created 3 endorsements (character, technical, collaboration)"
+echo "  - Verified all endorsement signatures"
+echo "  - Detected forged endorsement (wrong key)"
+echo "  - Demonstrated elided endorsement with inclusion proof"
+echo "  - Demonstrated web of trust concepts"
+echo "  - Upgraded attestation with endorsement reference"
+echo "  - Advanced provenance after changes"
+echo ""

--- a/tests/09-binding-agreements-TEST.sh
+++ b/tests/09-binding-agreements-TEST.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+#
+# Tutorial 09: Binding Agreements - Test Script
+#
+# Tests all commands from Tutorial 09, verifying:
+# - Contract-signing key creation
+# - CLA document creation and signing
+# - Ben's verification workflow
+# - CLA acceptance recording
+# - Herd privacy demonstration
+#
+# Usage: bash tests/09-binding-agreements-TEST.sh
+
+set -euo pipefail
+
+echo "========================================"
+echo "Tutorial 09: Binding Agreements"
+echo "========================================"
+echo ""
+
+# Create output directory
+OUTPUT_DIR="output/xid-tutorial09-$(date +%Y%m%d%H%M%S)"
+mkdir -p "$OUTPUT_DIR"
+
+echo "=== Part I: Setup and Contract Keys ==="
+echo ""
+
+echo "Step 1: Create Amira's XID..."
+
+# Create Amira's XID with provenance tracking
+XID=$(envelope generate keypairs --signing ed25519 | \
+    envelope xid new --nickname "BRadvoc8" --generator include --sign inception)
+
+UNWRAPPED_XID=$(envelope extract wrapped "$XID")
+XID_ID=$(envelope xid id "$UNWRAPPED_XID")
+
+echo "✅ Created Amira's XID: $XID_ID"
+echo ""
+
+echo "Step 2: Create contract-signing key..."
+
+# Generate contract-signing keys (limited purpose)
+CONTRACT_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+CONTRACT_PUBKEYS=$(envelope generate pubkeys "$CONTRACT_PRVKEYS")
+
+echo "✅ Contract-signing key created"
+echo ""
+
+echo "Step 3: Register contract key with purpose..."
+
+# Add contract key with limited purpose
+CONTRACT_KEY_ASSERTION=$(envelope subject type string "ContractSigningKey")
+CONTRACT_KEY_ASSERTION=$(envelope assertion add pred-obj string "publicKey" string "$CONTRACT_PUBKEYS" "$CONTRACT_KEY_ASSERTION")
+CONTRACT_KEY_ASSERTION=$(envelope assertion add pred-obj string "purpose" string "CLA and legal document signing only" "$CONTRACT_KEY_ASSERTION")
+CONTRACT_KEY_ASSERTION=$(envelope assertion add pred-obj string "addedOn" date "2026-01-21T00:00:00Z" "$CONTRACT_KEY_ASSERTION")
+
+echo "✅ Contract key registered with limited purpose"
+echo ""
+echo "Contract key assertion:"
+envelope format "$CONTRACT_KEY_ASSERTION"
+echo ""
+
+echo "=== Part II: CLA Creation and Signing ==="
+echo ""
+
+echo "Step 4: Create CLA document..."
+
+# Create the CLA content
+CLA=$(envelope subject type string "Individual Contributor License Agreement")
+
+# Add the project information
+CLA=$(envelope assertion add pred-obj string "project" string "SecureAuth Library" "$CLA")
+CLA=$(envelope assertion add pred-obj string "projectMaintainer" string "Ben (SecurityMaintainer)" "$CLA")
+CLA=$(envelope assertion add pred-obj string "licenseType" string "Apache-2.0" "$CLA")
+
+# Add the grant terms
+CLA=$(envelope assertion add pred-obj string "grantsCopyrightLicense" string "perpetual, worldwide, non-exclusive, royalty-free" "$CLA")
+CLA=$(envelope assertion add pred-obj string "grantsPatentLicense" string "for contributions containing patentable technology" "$CLA")
+
+# Add contributor representations
+CLA=$(envelope assertion add pred-obj string "contributorRepresents" string "original work with authority to grant license" "$CLA")
+
+# Add contributor identity
+CLA=$(envelope assertion add pred-obj string "contributor" string "$XID_ID" "$CLA")
+CLA=$(envelope assertion add pred-obj string "contributorNickname" string "BRadvoc8" "$CLA")
+CLA=$(envelope assertion add pred-obj string "signedOn" date "2026-01-21T00:00:00Z" "$CLA")
+
+# Mark as agreement type
+CLA=$(envelope assertion add pred-obj known isA string "ContributorLicenseAgreement" "$CLA")
+
+echo "✅ CLA document created"
+echo ""
+echo "CLA content:"
+envelope format "$CLA" | head -15
+echo ""
+
+echo "Step 5: Sign CLA with contract key..."
+
+CLA_SIGNED=$(envelope sign --signer "$CONTRACT_PRVKEYS" "$CLA")
+
+echo "✅ CLA signed by BRadvoc8"
+echo ""
+
+echo "=== Part III: Ben's Verification Workflow ==="
+echo ""
+
+echo "Ben's verification workflow:"
+echo "============================"
+
+echo "1. Verify signature..."
+if envelope verify --verifier "$CONTRACT_PUBKEYS" "$CLA_SIGNED"; then
+    echo "   ✅ Signature valid"
+else
+    echo "   ❌ Signature verification failed"
+    exit 1
+fi
+echo ""
+
+echo "1b. Test forgery detection..."
+
+# Attacker creates fake CLA claiming to be BRadvoc8
+FAKE_CLA=$(envelope subject type string "Individual Contributor License Agreement")
+FAKE_CLA=$(envelope assertion add pred-obj string "contributor" string "$XID_ID" "$FAKE_CLA")
+FAKE_CLA=$(envelope assertion add pred-obj string "contributorNickname" string "BRadvoc8" "$FAKE_CLA")
+
+# Attacker signs with their own key (not BRadvoc8's contract key)
+ATTACKER_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+FAKE_CLA_SIGNED=$(envelope sign --signer "$ATTACKER_PRVKEYS" "$FAKE_CLA")
+
+# Verification against BRadvoc8's real contract key should fail
+if envelope verify --verifier "$CONTRACT_PUBKEYS" "$FAKE_CLA_SIGNED" 2>/dev/null; then
+    echo "   ❌ Forged CLA should NOT have verified"
+    exit 1
+else
+    echo "   ✅ Forgery correctly rejected (signature doesn't match contract key)"
+fi
+echo ""
+
+echo "2. Confirm key belongs to BRadvoc8..."
+echo "   Contract key registered to: BRadvoc8 ($XID_ID)"
+echo "   Purpose: CLA and legal document signing only"
+echo "   ✅ Key association confirmed"
+echo ""
+
+echo "3. Review contributor reputation (optional)..."
+echo "   - DevReviewer: Technical endorsement (security collaboration)"
+echo "   - SecurityMaintainer: Collaboration endorsement"
+echo "   - Charlene: Character endorsement"
+echo "   ✅ Reputation verified"
+echo ""
+
+echo "Step 6: Ben accepts and records CLA..."
+
+# Ben creates his acceptance
+ACCEPTANCE=$(envelope subject type string "CLA Acceptance")
+CLA_DIGEST=$(envelope digest "$CLA_SIGNED")
+ACCEPTANCE=$(envelope assertion add pred-obj string "accepts" string "$CLA_DIGEST" "$ACCEPTANCE")
+ACCEPTANCE=$(envelope assertion add pred-obj string "contributor" string "$XID_ID" "$ACCEPTANCE")
+ACCEPTANCE=$(envelope assertion add pred-obj string "contributorNickname" string "BRadvoc8" "$ACCEPTANCE")
+ACCEPTANCE=$(envelope assertion add pred-obj string "acceptedOn" date "2026-01-21T00:00:00Z" "$ACCEPTANCE")
+ACCEPTANCE=$(envelope assertion add pred-obj string "acceptedBy" string "Ben (SecurityMaintainer)" "$ACCEPTANCE")
+
+# Ben signs with his maintainer key
+BEN_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+BEN_PUBKEYS=$(envelope generate pubkeys "$BEN_PRVKEYS")
+
+ACCEPTANCE_SIGNED=$(envelope sign --signer "$BEN_PRVKEYS" "$ACCEPTANCE")
+
+echo "4. Record acceptance..."
+echo "   ✅ CLA accepted and recorded"
+echo ""
+
+# Verify Ben's signature on acceptance
+if envelope verify --verifier "$BEN_PUBKEYS" "$ACCEPTANCE_SIGNED"; then
+    echo "   ✅ Ben's acceptance signature verified"
+else
+    echo "   ❌ Ben's acceptance signature failed"
+    exit 1
+fi
+echo ""
+
+echo "=== Part IV: Contribution Enabled ==="
+echo ""
+
+echo "5. Grant repository access..."
+echo "   - Contributor: BRadvoc8"
+echo "   - Access level: Push to feature branches"
+echo "   - Restrictions: Cannot push to main, cannot modify settings"
+echo "   ✅ Access granted"
+echo ""
+
+echo "============================"
+echo ""
+echo "BRadvoc8's first contribution:"
+echo "  PR #847: Add constant-time comparison for auth tokens"
+echo "  Status: Merged"
+echo ""
+
+echo "=== Part V: Herd Privacy Demonstration ==="
+echo ""
+
+echo "Project contributors with signed CLAs:"
+echo "  1. BRadvoc8 (Amira)"
+echo "  2. CryptoGuardian"
+echo "  3. SecureDevX"
+echo "  4. PrivacyFirst99"
+echo "  5. AuthExpert"
+echo "  ... and 45 others"
+echo ""
+echo "Total: 50 pseudonymous contributors"
+echo ""
+
+echo "Herd privacy effect:"
+echo "  | Contributors | Observer's Challenge    |"
+echo "  |--------------|-------------------------|"
+echo "  | 1            | Trivial to identify     |"
+echo "  | 10           | Difficult to identify   |"
+echo "  | 50           | Needle in haystack      |"
+echo "  | 500          | Effectively anonymous   |"
+echo ""
+
+echo "=== Part VI: Wrap-Up ==="
+echo ""
+
+# Save artifacts
+echo "$CLA_SIGNED" > "$OUTPUT_DIR/cla-signed-bradvoc8.envelope"
+echo "$ACCEPTANCE_SIGNED" > "$OUTPUT_DIR/cla-acceptance-ben.envelope"
+echo "$CONTRACT_PUBKEYS" > "$OUTPUT_DIR/contract-pubkeys.envelope"
+echo "$XID" > "$OUTPUT_DIR/BRadvoc8-xid.envelope"
+
+echo "Saved files to $OUTPUT_DIR:"
+ls -la "$OUTPUT_DIR"
+echo ""
+
+echo "========================================"
+echo "Tutorial 09 Test: ALL PASSED ✅"
+echo "========================================"
+echo ""
+echo "Summary:"
+echo "  - Created contract-signing key with limited purpose"
+echo "  - Created and signed CLA document"
+echo "  - Ben verified signature and key association"
+echo "  - Ben accepted and recorded CLA"
+echo "  - Demonstrated repository access grant"
+echo "  - Illustrated herd privacy protection"
+echo ""
+echo "The complete journey (T01-T09):"
+echo "  T01: Self-sovereign identity"
+echo "  T02: Verifiable and fresh"
+echo "  T03: External credentials"
+echo "  T04: Cross-verified accounts"
+echo "  T05: Public attestations"
+echo "  T06: Committed sensitive claims"
+echo "  T07: Encrypted sharing"
+echo "  T08: Peer endorsements"
+echo "  T09: CLA signed, contribution enabled"
+echo ""
+echo "BRadvoc8 can now contribute pseudonymously!"
+echo ""

--- a/tutorials/01-your-first-xid.md
+++ b/tutorials/01-your-first-xid.md
@@ -2,7 +2,8 @@
 
 This tutorial demonstrates how to create a basic XID (eXtensible IDentifier) that enables pseudonymous contributions while maintaining security. It does so through the story of [Amira](https://w3c-ccg.github.io/amira/), a software developer with a politically sensitive background who wants to contribute to social impact projects without risking her professional position or revealing her identity.
 
-**Time to complete: 10-15 minutes**
+**Time to complete**: ~10-15 minutes
+**Difficulty**: Beginner
 
 > **Related Concepts**: Before or after completing this tutorial, you may want to read about [XID Fundamentals](../concepts/xid.md) and [Gordian Envelope Basics](../concepts/gordian-envelope.md) to understand the theoretical foundations.
 
@@ -25,7 +26,7 @@ This tutorial demonstrates how to create a basic XID (eXtensible IDentifier) tha
 
 Amira is a successful software developer working at a prestigious multinational bank in Boston. With her expertise in distributed systems security, she earns a comfortable living, but she wants more purpose in her work. She is considering contributing to social-impact programs, but she can't do so under her real name. That's because Amira's position is somewhat vulnerable. She's working on an H-1B visa, and in modern America, that could be revoked for any sort of activism. She also grew up in a politically tense region, and her work on social-impact projects could endanger family members back home. Yet she's deeply motivated to use her skills to help oppressed people globally. This tension between professional security and meaningful contribution creates a specific need.
 
-Anonymous submissions could resolve these issues, and Amira already has a pseuodnymous identity: "BRadvoc8" (Basic Rights Advocate). However, anonymous contributions lack credibility. Project maintainers need confidence in the quality and provenance of code, especially for socially important applications. Amira needs a better solution, one that protects her identity while allowing her to build a verifiable reputation for her skills. This would allow her to build trust through the quality of her work rather than existing credentials and so establish a consistent presence that can evolve over time. 
+Anonymous submissions could resolve these issues, and Amira already has a pseudonymous identity: "BRadvoc8" (Basic Rights Advocate). However, anonymous contributions lack credibility. Project maintainers need confidence in the quality and provenance of code, especially for socially important applications. Amira needs a better solution, one that protects her identity while allowing her to build a verifiable reputation for her skills. This would allow her to build trust through the quality of her work rather than existing credentials and so establish a consistent presence that can evolve over time.
 
 On the advice of her friend Charlene, Amira investigates RISK, a network that connects developers with social-impact projects and protects participants' privacy. It uses a Blockchain Commons technology called [XIDs](../concepts/xid.md): they enable pseudonymous identity with progressive trust development, allowing Amira to safely collaborate on projects aligned with her values while maintaining separation between her pseudonymous contributions and her legal identity, protecting herself from adversaries who might target her or her family for her contributions. Through RISK, Amira can connect with project leaders such as Ben, who runs a women's services non-profit that Amira wishes to contribute to.
 
@@ -35,22 +36,23 @@ XIDs provide significant advantages over standard cryptographic keys because the
 
 XIDs support rich metadata: structured attestations, endorsements, and claims that describe your skills. Others can also make cryptographically verifiable claims about you through peer attestation. You can then selectively share different information with different parties, or use progressive trust to expand what you reveal to an individual over time, all while keeping other details private by eliding it. XIDs preserve the cryptographic integrity of the metadata even when portions are elided.
 
-## Step 0: Setting Up Your Work Space
+## Step 0: Setting Up Your Workspace
 
-This tutorial depends on [`bc-envelope-cli`](https://github.com/BlockchainCommons/bc-envelope-cli-rust), a Rust-based command-line interface.
+This tutorial depends on [`bc-envelope-cli`](https://github.com/BlockchainCommons/bc-envelope-cli-rust), a Rust-based command-line interface. It can be easily installed using the `cargo` package management tool:
 
-It can be easily installed using the `cargo` package management tool:
 ```
 cargo install bc-envelope-cli
 ```
-If you want to optionally check Provenance Marks, you can also install the Provenance Mark CLI with `cargo`:
+
+If you want to optionally check Provenance Marks, you can also install the Provenance Mark CLI:
+
 ```
 cargo install provenance-mark-cli
 ```
 
 If you don't have `cargo` installed, see [_The Cargo Book_](https://doc.rust-lang.org/cargo/getting-started/installation.html) for easy installation instructions.
 
-## Step 1: Creating Your XID
+## Step 1: Create Your XID
 
 Now that we understand why XIDs are valuable, let's help Amira create her "BRadvoc8" identity. This first tutorial is deliberately simple to get you started with the basics. In subsequent tutorials, we'll explore more advanced features like data minimization and rich persona structures.
 
@@ -78,38 +80,38 @@ fi
 │ Created your XID: BRadvoc8
 ```
 
-This command runs the `envelope` command twice.
+This command runs the `envelope` command twice:
 
-1. It uses `envelope generate keypairs` to generate an Ed25519 keypair (the same algorithm SSH, git, and Signal use). This generates two URs, containing the private and public keys, respectively.
-2. It uses `envelope xid new` to create a XID based on that Ed25519 keypair. This generates a XID Document (XIDDoc), which can be read as a Gordian Envelope.
+1. `envelope generate keypairs` creates an Ed25519 keypair (the same algorithm SSH, git, and Signal use). This generates two URs, containing the private and public keys, respectively.
+2. `envelope xid new` creates a XID based on that Ed25519 keypair. This generates a XID Document (XIDDoc), which can be read as a Gordian Envelope.
 
 Several arguments to the second command affect how the XID Document is produced:
 
-1. Your private key is kept in your XID structure, but `--private encrypt` encrypts it, with `--encrypt-password` allowing its decryption with a password.
-2. A set `--nickname` is added to the XID structure.
-3. A provenance mark is added to the XID structure with `--generator encrypt`.
-4. The entire XID is "wrapped" and then signed with your inception key thanks to `--sign inception`, which allows others to verify its authenticity.
+1. `--private encrypt` keeps private keys but encrypts them, with `--encrypt-password` allowing decryption with a password.
+2. `--nickname` adds an identity label to the XID structure.
+3. `--generator encrypt` adds a provenance mark to the XID structure (encrypted).
+4. `--sign inception` wraps and signs the entire XID, allowing others to verify its authenticity.
 
-> :warning: **Private Keys On Board**: Your XID contains your private keys (encrypted with your password). Though they are encrypted, you should still be leary of distributing a XID file that contains those private keys. Fortunately, you can elide (remove) that data, as described below. Obviously, you must also be careful to protect your password.
+> :warning: **Private Keys On Board**: Your XID contains your private keys (encrypted with your password). Though they are encrypted, you should still be wary of distributing a XID file that contains those private keys. Fortunately, you can elide (remove) that data, as described below. Obviously, you must also be careful to protect your password.
 
 A XID builds on several other Blockchain Commons technologies, primarily [Gordian Envelope](../concepts/gordian-envelope.md) and Provenance Marks.
 
-> :book: ***What is a provenance mark?*** A provenance mark is a forward-commitment hash chain. It will be used to record the evolution of this identity, showing that each version is linked to the previous one (and also, which is the newest version of a set).
+> :book: **What is a provenance mark?** A provenance mark is a forward-commitment hash chain. It will be used to record the evolution of this identity, showing that each version is linked to the previous one (and also, which is the newest version of a set).
 
-> :book: **What is a wrapped envelope?** A Gordian Envelope is a package of informational triplets in the form of subject-predicate-object. An assertion (the predicate and the object) always apply to a specific subject. To make an assertion apply to more information, you wrap the envelope, and then apply the assertion to the wrapped envelope. Signatures are assertions, so for a signature to apply to an entire envelope (in this case, all of the XID information), it must be wrapped prior to signing.
+> :book: **What is a wrapped envelope?** A Gordian Envelope is a package of informational triplets in the form of subject-predicate-object. An assertion (the predicate and the object) always applies to a specific subject. To make an assertion apply to more information, you wrap the envelope, and then apply the assertion to the wrapped envelope. Signatures are assertions, so for a signature to apply to an entire envelope (in this case, all of the XID information), it must be wrapped prior to signing.
 
-> :brain: **Learn more**: The [Signing and Verification](../concepts/signing.md) concept doc explains the cryptographic details of many of these elements. 
+> :brain: **Learn more**: The [Signing and Verification](../concepts/signing.md) concept doc explains the cryptographic details of many of these elements.
 
-### View your XID structure
+### View Your XID Structure
 
-The `envelope format` command can always be used to display a human-readable version of a Gordian Envelope, including a XID Document.
+The `envelope format` command can always be used to display a human-readable version of a Gordian Envelope, including a XID Document:
 
 ```
 envelope format "$XID"
 
 │ {
 │     XID(c7e764b7) [
-│         'key': PublicKeys(88d90933, SigningPublicKey(c7e764b7, Ed25519PublicKey(a1fae6ca)), EncapsulationPublicKey(a20a01e7, X25519PublicKey(a20a01e7))) [
+│         'key': PublicKeys(88d90933, SigningPublicKey(c5385c8f, Ed25519PublicKey(a1fae6ca)), EncapsulationPublicKey(a20a01e7, X25519PublicKey(a20a01e7))) [
 │             {
 │                 'privateKey': ENCRYPTED [
 │                     'hasSecret': EncryptedKey(Argon2id)
@@ -139,17 +141,17 @@ Here's what all the sections mean:
 
 - The curly braces `{ }` indicate wrapping, which is required for signing.
    - The signature occurs at the end under `signed`, with the `[ ]` indicating that it's an assertion on the `{ }` wrapped envelope. It confirms the entire document is cryptographically signed with the inception key.
--  `XID(c7e764b7)` is Amira's unique identifier, derived from her public key. This identifier never changes.
+- `XID(c7e764b7)` is Amira's unique identifier, derived from her public key. This identifier never changes.
 - The `PublicKeys(...)` section contains two public keys and is safe to share.
    - The `privateKey` section has been `ENCRYPTED`, indicating that the private keys are protected.
-      -  The `'hasSecret': EncryptedKey(Argon2id)` notation indicates that the private keys are encrypted with Argon2id, a modern algorithm designed to resist brute-force attacks.
-      - `salt` is a random value that further obscures its subject. It's applied to the wrapped `{ }` section including the privatekey (and also used later for the provenance mark.
+      - The `'hasSecret': EncryptedKey(Argon2id)` notation indicates that the private keys are encrypted with Argon2id, a modern algorithm designed to resist brute-force attacks.
+      - `salt` is a random value that further obscures its subject.
    - The `allow` statement determines what access these keys have to this identity, as described in [key management](../concepts/key-management.md). By default, keys have total access (`All`).
-   - The `nickname` is inside the `PublicKeys` section, not at the top level. That's because a nickname labels a key, not the XID Document. Later aeys could have different nicknames while maintaining the same XID identity.
+   - The `nickname` is inside the `PublicKeys` section, not at the top level. That's because a nickname labels a key, not the XID Document. Later keys could have different nicknames while maintaining the same XID identity.
 - The `ProvenanceMark(...)` is a "genesis" mark: the first in a chain that tracks this identity's evolution.
-   - The encrypted `provenanceGenerator` is the secret that created this mark and will create all future marks when Amira updates her XIDDoc. 
+   - The encrypted `provenanceGenerator` is the secret that created this mark and will create all future marks when Amira updates her XIDDoc.
 
-Note that a XID actually includes two keypairs that are bundled together: 
+Note that a XID actually includes two keypairs that are bundled together:
 - a `Signing` keypair for creating and verifying signatures.
 - an `Encapsulation` keypair for encryption and decryption.
 
@@ -157,11 +159,11 @@ Your inception key is the `SigningPublicKey`. This is the key that defines your 
 
 > :warning: **XIDs Remain Consistent**: The same keypairs always produce the same XID identifier because it's derived from the public key. If you regenerate from the same keys, you get the same identity. If you lose the keys, you lose the identity, just as with SSH.
 
-As shown, the public halves of the keypair are readable by anyone, while the private halves are encrypted with your password; the public halves are readable by anyone. This mirrors how SSH works with `id_rsa` and `id_rsa.pub`, except your XID bundles both into a single document.
+As shown, the public halves of the keypair are readable by anyone, while the private halves are encrypted with your password. This mirrors how SSH works with `id_rsa` and `id_rsa.pub`, except your XID bundles both into a single document.
 
 #### A Review of Envelope Structure
 
-If you are familar with envelope structure (here) and envelope format (below), then you can skip ahead to Step 2 and create a public version of XID. If, however, you are not that familiar with Gordian Envelope, then read on.
+If you are familiar with envelope structure (here) and envelope format (below), then you can skip ahead to Step 2 and create a public version of XID. If, however, you are not that familiar with Gordian Envelope, then read on.
 
 As noted, every envelope has a **subject** (the main thing) and **assertions** (claims about that thing), which each include a **predicate** and an **object**. This usually means the subject predicates the object or the subject has a predicate of the object.
 
@@ -177,7 +179,7 @@ Here's how that structure appears in the sample XID Document:
 }
 ```
 
-The XID identifier `XID(c7e764b7)` is the subject. The assertions make claims about it: "this XID has these public keys" and "this XID has this provenance history."=
+The XID identifier `XID(c7e764b7)` is the subject. The assertions make claims about it: "this XID has these public keys" and "this XID has this provenance history."
 
 This pattern nests. Look inside the `'key'` assertion:
 
@@ -188,7 +190,7 @@ This pattern nests. Look inside the `'key'` assertion:
 ]
 ```
 
-The `PublicKeys` object is itself a subject with its own assertions. It `allow`s all access to the XID and it contains an `ENCRYPTED` `privateKey`. This recursive structure lets you build arbitrarily rich identity documents. In Tutorial 03, you'll add your GitHub account and SSH keys as attachments—vendor-qualified containers for application-specific data. 
+The `PublicKeys` object is itself a subject with its own assertions. It `allow`s all access to the XID and it contains an `ENCRYPTED` `privateKey`. This recursive structure lets you build arbitrarily rich identity documents. In Tutorial 03, you'll add your GitHub account and SSH keys as attachments—vendor-qualified containers for application-specific data.
 
 Assertions can be added, removed, or hidden independently, no matter where they are in an envelope document. This is a key insight for their usage (and in fact you'll be hiding individual assertions momentarily).
 
@@ -200,14 +202,14 @@ The hex codes in parentheses are digest fragments that let you quickly identify 
 
 The other thing of particular note is the quoted data. There are two styles of quotes:
 
-> - **Single quotes** (`'key'`, `'nickname'`, `'All'`) designate **Known values**. These are standardized terms from the Gordian Envelope specification. They can be subjects, predicates (`'allow'`), or objects (`'All'`). These ensure different tools understand your XIDDoc the same way.
-> - **Double quotes** (`"BRadvoc8"`, `"github"`) designate **Strings**. This is custom application data you define.
+- **Single quotes** (`'key'`, `'nickname'`, `'All'`) designate **Known values**. These are standardized terms from the Gordian Envelope specification. They can be subjects, predicates (`'allow'`), or objects (`'All'`). These ensure different tools understand your XIDDoc the same way.
+- **Double quotes** (`"BRadvoc8"`, `"github"`) designate **Strings**. This is custom application data you define.
 
-## Step 2: Creating a Public Version of Your XID by Elision
+## Step 2: Creating a Public Version by Elision
 
 Now Amira wants to create a shareable public version that does not contain her private key. She does this by using envelope's elision (removal) feature.
 
-To do so, she must find the digest (hash) of the private key assertion. Every thing in an envelope has a hash: it's how the envelope is built and how it maintains signatures (more on that momentarily). Ones she finds the right hash, she simply tells the Envelope CLI to remove it. 
+To do so, she must find the digest (hash) of the private key assertion. Every thing in an envelope has a hash: it's how the envelope is built and how it maintains signatures (more on that momentarily). Once she finds the right hash, she simply tells the Envelope CLI to remove it.
 
 ### Finding the Private Key Digest
 
@@ -227,7 +229,9 @@ Then we find the `key` assertion, which is a `known` value and extract the `Publ
 KEY_ASSERTION=$(envelope assertion find predicate known key "$UNWRAPPED_XID")
 KEY_OBJECT=$(envelope extract object "$KEY_ASSERTION")
 ```
-Finally, we can extract the `privateKey` assertion from _that_ and then record its digest.
+
+Finally, we can extract the `privateKey` assertion from _that_ and then record its digest:
+
 ```
 # Find the private key assertion within the key object
 PRIVATE_KEY_ASSERTION=$(envelope assertion find predicate known privateKey "$KEY_OBJECT")
@@ -239,7 +243,6 @@ then
 else
   echo "Error in private key retrieval"
 fi
-
 
 │ Found private key digest
 ```
@@ -255,17 +258,17 @@ echo "Created public version by eliding private key"
 │ Created public version by eliding private key
 ```
 
-The `envelope format` command shows that the public version no longer includes that whole branch of data.
+View the public version:
 
 ```
 envelope format "$PUBLIC_XID"
 
 │ {
 │     XID(c7e764b7) [
-│         'key': PublicKeys(88d90933, SigningPublicKey(c7e764b7, Ed25519PublicKey(a1fae6ca)), EncapsulationPublicKey(a20a01e7, X25519PublicKey(a20a01e7))) [
+│         'key': PublicKeys(32de0f2b) [
 │             'allow': 'All'
 │             'nickname': "BRadvoc8"
-|             ELIDED
+│             ELIDED                      ← Private key removed
 │         ]
 │         'provenance': ProvenanceMark(632330b4) [
 │             {
@@ -288,13 +291,31 @@ Note that this preserves the signature *despite* removing some of the data in th
 
 If you are already comfortable with the structure of Gordian Envelopes, how they hash data, and how data is signed, skip down to Step 3. Otherwise, read on.
 
-Gordian Envelope is built on hashes. Every subject, every predicate, every object, and every assertion has a hash. Leaves (such as subject, predicates, and objects) have hashes of the content of the leaf, while nodes (such as assertions, collections of assertions, and wrapped content) have hashes that are built from the hashes of the objects they contain. A signature is made not across the content of an envelope, but against the root (or top-level) hash of an envelope.
+Gordian Envelope is built on hashes. Every subject, every predicate, every object, and every assertion has a hash. Leaves (such as subjects, predicates, and objects) have hashes of the content of the leaf, while nodes (such as assertions, collections of assertions, and wrapped content) have hashes that are built from the hashes of the objects they contain. A signature is made not across the content of an envelope, but against the root (or top-level) hash of an envelope.
 
 When data is elided from an envelope, its content is removed, but the hash remains. That means that all of the node hashes above that leaf hash remain the same, including the root hash. Since it's the root hash that is signed, not the full envelope content, the signature remains valid.
 
-> :warning: **Root Hash is Not XID Identifier.** The root hash is composed from the hashes of _all_ the data within an envelope. It changes if you change the document. It's an identifier for a specific version of your XID Document. The XID identifier is the hash of your inception public key. It never changes. It's an identifier for your identity. 
+> :warning: **Root Hash is Not XID Identifier.** The root hash is composed from the hashes of _all_ the data within an envelope. It changes if you change the document. It's an identifier for a specific version of your XID Document. The XID identifier is the hash of your inception public key. It never changes. It's an identifier for your identity.
 
-You can verify your root hash does not change after you elide data with the `envelope digest` command:
+**Important distinction - XID identifier vs Envelope hash:**
+
+Notice `XID(c7e764b7)` is the same as before. But **this doesn't prove elision preserved the hash!** Here's why:
+
+- **`XID(c7e764b7)`** = XID identifier (derived from the inception public key)
+  - Stays the same across ALL versions of this identity
+  - Would be the same even if you completely changed the document
+  - Identifies the **entity**, not the document version
+
+- **Envelope digest** = Hash of the entire envelope structure
+  - Changes when document content changes
+  - THIS is what elision preserves
+  - THIS is what allows signatures to verify
+
+**Critical:** The XID identifier is persistent (based on inception public key), so seeing it unchanged proves nothing about hash preservation. We need to compare the **envelope digest**.
+
+### Proving Elision Preserves the Envelope Hash
+
+The tutorial claims that elision preserves the root hash. Let's **verify** this claim by comparing the digests:
 
 ```
 # Get digest of original XID (with encrypted private key)
@@ -308,7 +329,7 @@ echo "Original XID digest: $ORIGINAL_DIGEST"
 echo "Public XID digest:   $PUBLIC_DIGEST"
 
 if [ "$ORIGINAL_DIGEST" = "$PUBLIC_DIGEST" ]; then
-    echo "✅ VERIFIED: Digests are identical - elision preserved the root hash\!"
+    echo "✅ VERIFIED: Digests are identical - elision preserved the root hash!"
 else
     echo "❌ ERROR: Digests differ"
 fi
@@ -318,48 +339,60 @@ fi
 │ ✅ VERIFIED: Digests are identical - elision preserved the root hash!
 ```
 
-The digests are identical. You removed the private key, yet the hash didn't change. 
+The digests are identical. You removed the private key, yet the hash didn't change. How is that possible?
 
-## Step 3: Verifying a XID
+### Why Elision Preserves the Hash
 
-There are two ways to verify XIDs:
-* The signature can be verified against a public key.
-* The provenance mark can be validated.
+This seems impossible—normally, changing data changes its hash. But envelopes use a Merkle tree structure where each part has its own hash, and those hashes combine into the root hash. The root doesn't hash the content directly; it hashes the hashes.
 
-The signature is verified against a public key. Again, we have to dig down through the envelope to get to it:
 ```
-UNWRAPPED_XID=$(envelope extract wrapped "$XID")
+Envelope Root Hash
+    ├─ Subject Hash (XID identifier)
+    ├─ Assertion 1 Hash ('key' → PublicKeys)
+    ├─ Assertion 2 Hash ('provenance' → ProvenanceMark)
+    └─ Assertion 3 Hash (nested 'privateKey' → ENCRYPTED)
+```
+
+When you elide, you remove the content but keep its hash in the calculation. The `'privateKey': ENCRYPTED` assertion had hash `def456...` before elision. After elision, the marker `ELIDED` still uses that same hash `def456...` in the root calculation. Same inputs, same root hash.
+
+This is the foundation of selective disclosure. Amira signs her complete XIDDoc once, then creates different views by eliding different parts. Every view has the same root hash, so every view passes signature verification. She can show Ben her GitHub attestations while showing the public nothing—all from the same signed document.
+
+> :brain: **Technical depth**: The Merkle tree structure is fully specified in the [Gordian Envelope IETF draft](https://developer.blockchaincommons.com/envelope/). Understanding how hashes compose is essential for advanced use cases like partial reveals and multi-party verification.
+
+> **Remember**: Don't confuse the XID identifier with the envelope digest. The XID identifier (`XID(c7e764b7)`) is the SHA-256 hash of the inception signing public key and never changes across document versions—it identifies Amira. The envelope digest identifies a specific document version and normally changes when you modify content. Elision is special: it's the only way to remove data without changing the digest.
+
+## Step 3: Verification
+
+Now let's verify both the signature and provenance on our XID:
+
+```
+# Extract public keys (the XID contains everything needed for verification)
 KEY_ASSERTION=$(envelope assertion find predicate known key "$UNWRAPPED_XID")
 KEY_OBJECT=$(envelope extract object "$KEY_ASSERTION")
 PUBLIC_KEYS=$(envelope extract ur "$KEY_OBJECT")
-```
-You can then use envelope's `verify` command to verify the signature of the `PUBLIC_XID` versus that public key:
 
-```
-envelope verify -v "$PUBLIC_KEYS" "$PUBLIC_XID" >/dev/null && echo "✅ Signature verified\!"
+# Verify the signature
+envelope verify -v "$PUBLIC_KEYS" "$PUBLIC_XID" >/dev/null && echo "✅ Signature verified!"
 
 │ ✅ Signature verified!
 ```
 
-This confirms that this XID Document has been signed by the owner of the public key within the document. Alternatively, if the public key were retrieved from a PKI or other published site, it would confirm that the document was signed by the owner of the published public key. In the future, this verification will demonstrate that updates of this XID Document continue to be signed by this original (inception) key.
-
-The provenance mark can similarly be verified. To do this, extract the Provenance Mark with the `xid provenance` command:
+Now verify the provenance mark - notice we can verify from the **public** XID:
 
 ```
+# Extract the provenance mark from the PUBLIC XID (no secrets needed!)
 PROVENANCE_MARK=$(envelope xid provenance get "$PUBLIC_XID")
-```
 
-Afterward, if you have installed the Provenance Mark CLI, you can validate the Provenance Mark:
-
-```
+# Check that it's a valid genesis mark
 provenance validate "$PROVENANCE_MARK"
 
 │ ✅ (silent success - provenance check passed!)
 ```
 
-Here's a more detailed report on what the Provenance Mark CLI is checking:
+Want to see what was verified? Get the detailed report:
 
 ```
+# Show detailed assessment report
 provenance validate --format json-pretty "$PROVENANCE_MARK"
 
 │ {
@@ -384,13 +417,25 @@ provenance validate --format json-pretty "$PROVENANCE_MARK"
 │ }
 ```
 
-The Provenance Mark CLI shows `has_genesis: true` and `sequence: 0`, meaning this is the first version in the chain with no issues found. In other words, you're just verifying that you have a Genesis Mark, which is the first provenance mark in a chain. (When you create more marks in the chain, you'll be able to verify that two provenance marks are connected, but that's for the future.
+Both checks passed using only the public XID—no secrets required. The signature confirms this XIDDoc is authentically from BRadvoc8 (signed by the inception key). The provenance shows `has_genesis: true` and `sequence: 0`, meaning this is the first version in the chain with no issues found.
 
-Here's a few things to note in your verification:
-* All verification was down with the `PUBLIC_XID`; no secret information is needed.
-* This demonstrates an asymmetry common in cryptography: Amira creates information with her secrets, and only she can update it. But after she distributes her public XID, anyone can check it.
+Notice the asymmetry: verifying signatures and provenance needs only public information, but creating signatures or advancing provenance requires secrets. This is why Amira can share her public XID freely—anyone can verify it, but only she can update it.
 
-## Step 4: Organizing Your Files
+> **Remember**: The provenance mark is public, but the generator that advances it is encrypted. In Tutorial 02, you'll see how provenance lets Ben verify he has the current version of BRadvoc8.
+
+## Reviewing the XID Creation Workflow
+
+The single command you ran combined several operations that would otherwise take eight or more steps. Understanding what happened helps when things go wrong.
+
+The `--private encrypt` flag encrypted your private keys with your password, following the SSH model: you can share the file freely because the secrets are protected. The public parts (nickname, public keys, provenance) remain readable to anyone.
+
+The `--generator encrypt` flag encrypted the provenance generator—the secret that creates provenance marks. The generator created the initial "genesis" mark you see now, and will create all subsequent marks when Amira updates her XIDDoc. The mark itself is public (it timestamps when this identity version was created), but the generator must stay secret. Only someone with the generator can advance the provenance chain, proving updates are legitimate.
+
+The `--sign inception` flag signed the entire document with the inception key. This is the sign-then-elide workflow: you sign the complete document (including encrypted private keys), then elide sensitive parts for sharing. Because elision preserves the hash, the signature verifies on both versions.
+
+> **Learn more**: The [Signing and Verification](../concepts/signing.md) concept doc explains the cryptographic details. Tutorial 02 shows how provenance enables freshness verification.
+
+## File Organization
 
 For real-world usage, Amira will organize her files in a dedicated directory. The pattern mirrors SSH: `BRadvoc8-xid.envelope` is like `id_rsa` (keep secret), and `BRadvoc8-xid-public.envelope` is like `id_rsa.pub` (safe to share).
 
@@ -402,72 +447,19 @@ xid-20251117/
 └── BRadvoc8-xid-public.format     # Human-readable version
 ```
 
-Your complete XID file contains everything: private keys (encrypted), public keys, nickname, provenance, and signature. If you lose this file without a backup, you lose your identity, just like losing `id_rsa`. Unlike SSH keys, your XID also includes identity metadata (nickname, permissions, provenance history), making it a complete, self-contained identity document rather than just raw key material.
-
-You might have many different public XID files, each elided in different ways. Obviously, you'll want to keep your private key out of all of them, but you might also decide to reveal different information to different people, as part of selective disclosure.
-
 The `.envelope` files contain the binary serialized format that tools work with. The `.format` files are human-readable versions for inspection. The timestamp-based directory keeps versions organized.
 
-## Example Script
+Your complete XID file contains everything: private keys (encrypted), public keys, nickname, provenance, and signature. If you lose this file without a backup, you lose your identity—just like losing `id_rsa`. Unlike SSH keys, your XID also includes identity metadata (nickname, permissions, provenance history), making it a complete, self-contained identity document rather than just raw key material.
 
-A complete working script implementing this tutorial is available at `tests/01-your-first-xid-TEST.sh`. Run it to see all steps in action:
+## The Bigger Picture
 
-```
-bash tests/01-your-first-xid-TEST.sh
-```
+What Amira created is more than a keypair. BRadvoc8's identity is fully under her control—no service provider issued it, no platform can suspend it. This is self-sovereign identity: she owns the keys and the resulting document.
 
-This script will create all the files shown in the File Organization section (below) with proper naming conventions and directory structure.
+This XID implements pseudonymity rather than anonymity. Anonymous contributions lack credibility; project maintainers can't trust them. But BRadvoc8 can build reputation over time through verifiable contributions while protecting Amira's real-world identity. It's the same model authors use with pen names: Mark Twain built a reputation while Samuel Clemens stayed private.
 
-## Summary: The Bigger Picture
+The encrypted XID can live anywhere—USB drive, email, cloud storage, even printed as a QR code—because it's a self-contained cryptographic object. The infrastructure is in the document itself, not in some external system.
 
-What Amira created is more than a keypair. She created the BRadvoc8 identity, which is fully under her control. No service provider issued it, and no platform can suspend it. This is self-sovereign identity: Amira owns the keys and the resulting document.
-
-Amira's XID implements pseudonymity rather than anonymity, and that's exactly what she wants. Anonymous contributions lack credibility; project maintainers can't trust them. But BRadvoc8 can build reputation over time through verifiable contributions while protecting Amira's real-world identity. It's the same model authors use with pen names: Mark Twain built a reputation while Samuel Clemens stayed private.
-
-The encrypted XID depends on no centralized structure. Because it's a self-contained cryptographic object, the XID can live anywhere: on a USB drive, in email, in cloud storage, even printed as a QR code. The infrastructure is in the document itself, not in some external system.
-
-## Exercises
-
-Try these to solidify your understanding:
-
-- Create your own XID with a pseudonym of your choice.
-- Experiment with different passwords.
-- Practice creating public versions by eliding private keys, then verify the signatures still work on the elided versions.
-- Save your XID to a file and reload it to confirm nothing was lost.
-
-## What's Next
-
-BRadvoc8 is now a basic, secure XID, but it has a problem: nobody can verify they have the current version. If Amira updates her XIDDoc tomorrow, how would Ben know he has stale data?
-
-**Tutorial 02: Making Your XID Verifiable** shows how to solve this. Amira will add a `dereferenceVia` assertion pointing to where her XID is published, then advance the provenance chain. Ben can then fetch the latest version and verify it's fresh.
-
-From there, Tutorial 03 adds attestations (GitHub account, SSH signing key), and Tutorial 04 shows Ben how to cross-verify those claims against external sources. Together, they enable the trust-building that comes in later tutorials.
-
-**Next Tutorial**: [Making Your XID Verifiable](02-making-your-xid-verifiable.md) - Publish your XID and enable freshness verification.
-
----
-
-[[EDITED TO HERE]]
-
-## Appendix I: Common Questions
-
-### Q: Why Ed25519 instead of Schnorr or other algorithms?
-
-**A:** Ed25519 is the industry standard (SSH, git, Signal) with wide compatibility and excellent security. Advanced users can use other algorithms (`--signing schnorr`, `--signing ecdsa`, `--signing mldsa44`), but Ed25519 is recommended for beginners.
-
-### Q: What if I lose my XID file?
-
-**A:** If you lose your `BRadvoc8-xid.envelope` file without a backup, **you lose your identity**. This is just like losing your SSH `id_rsa` file. There's no recovery mechanism without a backup - make sure to store encrypted copies in multiple secure locations.
-
-### Q: Can I use this XID on multiple devices?
-
-**A:** Yes! Copy your `BRadvoc8-xid.envelope` file to other devices. Since the private keys are encrypted, the file is reasonably safe to sync via cloud storage (as long as you have a strong passphrase!).
-
-**Like SSH keys**: You can use the same XID across multiple devices, just like you might copy `id_rsa` to a new machine. The XID identifier stays the same regardless of which device you're using. Unlike SSH keys, you can revoke a key pair while keeping your XID persistent.
-
-**Advanced (Tutorials ??-??)**: You can also create device-specific keys and delegate permissions, allowing each device to have its own key while maintaining a single XID identity.
-
-## Appendix II: Key Terminology
+## Appendix: Key Terminology
 
 > **XID (eXtensible IDentifier)** - The unique identifier for your identity, calculated as the SHA-256 hash of your inception signing public key. Persistent across all document versions because it's bound to that original key.
 >
@@ -493,6 +485,53 @@ From there, Tutorial 03 adds attestations (GitHub account, SSH signing key), and
 >
 > **Envelope Digest** - The root hash of an envelope structure; preserved across elision, enabling signature verification on different views of the same document.
 
+---
+
+## Common Questions
+
+### Q: Why Ed25519 instead of Schnorr or other algorithms?
+
+**A:** Ed25519 is the industry standard (SSH, git, Signal) with wide compatibility and excellent security. Advanced users can use other algorithms (`--signing schnorr`, `--signing ecdsa`, `--signing mldsa44`), but Ed25519 is recommended for beginners.
+
+### Q: What if I lose my XID file?
+
+**A:** If you lose your `BRadvoc8-xid.envelope` file without a backup, **you lose your identity**. This is just like losing your SSH `id_rsa` file. There's no recovery mechanism without a backup - make sure to store encrypted copies in multiple secure locations.
+
+### Q: Can I use this XID on multiple devices?
+
+**A:** Yes! Copy your `BRadvoc8-xid.envelope` file to other devices. Since the private keys are encrypted, the file is reasonably safe to sync via cloud storage (as long as you have a strong passphrase!).
+
+**Like SSH keys**: You can use the same XID across multiple devices, just like you might copy `id_rsa` to a new machine. The XID identifier stays the same regardless of which device you're using. Unlike SSH keys, you can revoke a key pair while keeping your XID persistent.
+
+**Advanced (Tutorials 10-12)**: You can also create device-specific keys and delegate permissions, allowing each device to have its own key while maintaining a single XID identity.
+
+## What's Next
+
+BRadvoc8 is now a basic, secure XID, but it has a problem: nobody can verify they have the current version. If she updates her XIDDoc tomorrow, how would Ben know he has stale data?
+
+**Tutorial 02: Making Your XID Verifiable** shows how to solve this. Amira will add a `dereferenceVia` assertion pointing to where her XID is published, then advance the provenance chain. Ben can then fetch the latest version and verify it's fresh.
+
+From there, Tutorial 03 adds attestations (GitHub account, SSH signing key), and Tutorial 04 shows Ben how to cross-verify those claims against external sources. Together, they enable the trust-building that comes in later tutorials.
+
+## Exercises
+
+Try these to solidify your understanding:
+
+- Create your own XID with a pseudonym of your choice.
+- Experiment with different passwords.
+- Practice creating public versions by eliding private keys, then verify the signatures still work on the elided versions.
+- Save your XID to a file and reload it to confirm nothing was lost.
+
+## Example Script
+
+A complete working script implementing this tutorial is available at `tests/01-your-first-xid-TEST.sh`. Run it to see all steps in action:
+
+```
+bash tests/01-your-first-xid-TEST.sh
+```
+
+This script will create all the files shown in the File Organization section with proper naming conventions and directory structure.
 
 ---
 
+**Next Tutorial**: [Making Your XID Verifiable](02-making-your-xid-verifiable.md) - Publish your XID and enable freshness verification.

--- a/tutorials/03-offering-self-attestation.md
+++ b/tutorials/03-offering-self-attestation.md
@@ -4,7 +4,9 @@ In Tutorial 02, Amira made her BRadvoc8 XIDDoc verifiable by publishing it at a 
 
 This tutorial shows how Amira adds attestations to her XID—verifiable claims about her activities. She'll link her GitHub account and SSH signing key, creating evidence that Ben can later verify against external sources.
 
-**Time to complete: 15-20 minutes**
+**Time to complete**: ~15-20 minutes
+**Difficulty**: Beginner
+**Builds on**: Tutorials 01-02
 
 > **Related Concepts**: This tutorial covers self-attestation. For deeper understanding, see [Attestation & Endorsement Model](../concepts/attestation-endorsement-model.md) for the framework of claims and verification, [Fair Witness](../concepts/fair-witness.md) for making trustworthy assertions, and [Pseudonymous Trust Building](../concepts/pseudonymous-trust-building.md) for building reputation while maintaining privacy.
 
@@ -32,9 +34,9 @@ This is the difference between saying "I'm a developer" and showing a commit his
 
 ---
 
-## Part I: Understanding Attachments
+## About Attachments
 
-Before adding attestations, you need to understand how XIDs handle structured data.
+*If you're ready to start adding attestations, skip to Part II. Otherwise, read on to understand how XIDs handle structured data.*
 
 ### Attachments vs Raw Assertions
 
@@ -60,7 +62,7 @@ envelope xid attachment add \
 
 The `--vendor` qualifier indicates who defined this attachment format. Using `"self"` means Amira defined it for her own use. Organizations might use domain names (`"com.example"`) for their custom formats.
 
-### Why Attachments?
+### :book: Why Attachments?
 
 Attachments solve several problems. They namespace custom data so different applications don't collide. They keep the XID core clean—your identity isn't cluttered with application-specific details. And they're explicitly optional: tools that don't understand an attachment can safely ignore it while still processing the XID.
 
@@ -68,13 +70,29 @@ Most importantly, attachments allow **arbitrary predicates**. The XID core has a
 
 Think of attachments as labeled boxes you attach to your identity. The labels tell others what's inside and who packed it. Ben might understand `vendor: "self"` GitHub attachments but ignore `vendor: "com.example"` attachments he doesn't recognize.
 
+> :brain: **Learn more**: The [Attestation & Endorsement Model](../concepts/attestation-endorsement-model.md) concept doc explains the full framework for claims, evidence, and verification in XIDs.
+
 ---
 
 ## Part II: Amira Adds Her GitHub Account
 
-Now let's add Amira's GitHub account as an attachment.
+Now for the hands-on work. You'll generate an SSH signing key, create a proof that you control it, bundle everything into a GitHub account attachment, and publish the updated XID. By the end, your XID will contain verifiable claims that Ben can check against external sources.
 
-> ⚠️ **Important: Your Output Will Differ**
+### Step 0: Verify Dependencies
+
+Ensure you have the required tools:
+
+```
+envelope --version
+provenance --version
+
+│ bc-envelope-cli 0.32.0
+│ provenance-mark-cli 0.6.0
+```
+
+If not installed, see Tutorial 01 Step 0 for installation instructions.
+
+> :warning: **Important: Your Output Will Differ**
 >
 > From this point forward, tutorial examples show output from the **real published BRadvoc8 XID** at `github.com/BRadvoc8/BRadvoc8`. When you follow along with your own XID:
 >
@@ -84,7 +102,7 @@ Now let's add Amira's GitHub account as an attachment.
 >
 > **This is expected.** The structure and workflow remain the same—only the specific values change. Focus on understanding what each step accomplishes, not matching exact output.
 
-### Step 1: Set Up Your Environment
+### Step 1: Load Your XID
 
 Load your XID from Tutorial 02:
 
@@ -102,7 +120,7 @@ envelope xid id "$XID"
 │ ur:xid/hdcxltkttdhsjztodsfygmfzdmvajocftohtrltabzbazmkbsalnhfhywfneaohycfynbejokkda
 ```
 
-### Step 2: Generate an SSH Signing Key
+### Step 2: Generate SSH Signing Key
 
 Amira needs an SSH key specifically for signing Git commits. This is different from SSH authentication keys—GitHub maintains them separately.
 
@@ -121,7 +139,7 @@ echo "$SSH_EXPORT"
 │ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOiOtuf9hwDBjNXyjvjHMKeLQKyzT8GcH3tLvHNKrXJe
 ```
 
-> **SSH Signing vs Authentication**:
+> :book: **SSH Signing vs Authentication**:
 >
 > GitHub has two separate SSH key registries. Authentication keys (`/users/{user}/keys`) control access to repositories. Signing keys (`/users/{user}/ssh_signing_keys`) verify commit signatures. Amira is adding a signing key—it proves her commits are authentic, not that she can push to repos.
 
@@ -139,7 +157,7 @@ The `envelope generate prvkeys --signing ssh-ed25519` command creates keys in SS
 >
 > The real BRadvoc8 XID uses an existing key that was registered on GitHub in May 2025.
 
-> **Key Separation**:
+> :warning: **Key Separation**:
 >
 > Amira now has multiple keys serving different purposes:
 >
@@ -153,7 +171,7 @@ The `envelope generate prvkeys --signing ssh-ed25519` command creates keys in SS
 >
 > Even the XID signing key can be rotated if compromised—you can add a new signing key and revoke the old one while keeping the same XID identifier. Your identity persists across key changes.
 
-### Step 3: Create a Proof-of-Control
+### Step 3: Create Proof-of-Control
 
 Before adding the key to her XID, Amira creates a proof that she controls it. This is a signed statement declaring ownership at a specific point in time:
 
@@ -176,11 +194,45 @@ envelope format "$PROOF"
 
 This proof demonstrates that whoever holds the SSH private key signed a statement claiming association with BRadvoc8 on this date.
 
-> **Temporal Limitation**:
+#### Verifying the Proof
+
+Ben can later verify this proof using the public key embedded in the XID:
+
+```
+# Verify the proof signature
+if envelope verify -v "$SSH_PUBKEYS" "$PROOF" >/dev/null 2>&1; then
+    echo "✅ Proof signature verified - key holder signed this statement"
+else
+    echo "❌ Proof signature FAILED"
+fi
+
+│ ✅ Proof signature verified - key holder signed this statement
+```
+
+This confirms the statement was signed by whoever controls the SSH private key. It doesn't prove *who* that is—just that they could sign.
+
+#### What If the Proof Was Tampered?
+
+```
+# Simulate tampering - an attacker changes the date
+TAMPERED_PROOF=$(echo "$PROOF" | sed 's/2026-01-21/2025-01-01/')
+
+if envelope verify -v "$SSH_PUBKEYS" "$TAMPERED_PROOF" >/dev/null 2>&1; then
+    echo "✅ Signature verified"
+else
+    echo "❌ Signature FAILED - tampering detected!"
+fi
+
+│ ❌ Signature FAILED - tampering detected!
+```
+
+Any modification invalidates the signature. Ben can trust that the proof content matches exactly what was signed.
+
+> :book: **Temporal Limitation**:
 >
 > This proof is a snapshot, not an ongoing guarantee. It proves Amira controlled the key when she signed—it doesn't prove she controls it now, or that she'll control it tomorrow. Keys can be compromised. Ben will need to check external sources (GitHub's current registry, recent signed commits) for stronger assurance. Tutorial 04 covers this verification.
 
-### Step 4: Build the GitHub Account Payload
+### Step 4: Build GitHub Account Payload
 
 Now assemble the attachment payload—all the information about Amira's GitHub presence:
 
@@ -215,7 +267,23 @@ envelope format "$GITHUB_ACCOUNT"
 │ ]
 ```
 
-> **Why This Structure?**
+This builds the payload step by step. Each `envelope assertion add` command adds one predicate-object pair:
+
+| Command | Predicate Type | Purpose |
+|---------|---------------|---------|
+| `subject type string "$XID_NAME"` | (creates subject) | Sets "BRadvoc8" as the envelope subject |
+| `known isA string "GitHubAccount"` | Known (`'isA'`) | Declares what this envelope represents |
+| `known dereferenceVia uri "..."` | Known (`'dereferenceVia'`) | Points to authoritative source |
+| `string "sshSigningKeysURL" uri "..."` | Custom (`"sshSigningKeysURL"`) | Where to verify the key is registered |
+| `string "sshSigningKey" ur "$SSH_PUBKEYS"` | Custom (`"sshSigningKey"`) | The key in structured UR format |
+| `string "sshSigningKeyText" string "..."` | Custom (`"sshSigningKeyText"`) | The key in human-readable format |
+| `string "sshSigningKeyProof" envelope "$PROOF"` | Custom (`"sshSigningKeyProof"`) | Embeds the signed proof-of-control |
+| `string "createdAt" date "..."` | Custom (`"createdAt"`) | When this attestation was created |
+| `string "updatedAt" date "..."` | Custom (`"updatedAt"`) | When this attestation was last modified |
+
+Notice the pattern: `known` predicates use envelope-standard semantics (single quotes in output), while `string` predicates are domain-specific (double quotes in output).
+
+> :book: **Why This Structure?**
 >
 > The `dereferenceVia` URL points to the GitHub account itself (not the signing keys) because `isA` declares this is a "GitHubAccount". In envelope design, `dereferenceVia` must point to the authoritative source of whatever the subject claims to be—the type and the dereference target must match semantically. If someone fetches the `dereferenceVia` URL expecting a GitHub account, they should get account information, not a list of SSH keys.
 >
@@ -227,7 +295,7 @@ Notice what we included: the account name as subject, a type marker (`isA: "GitH
 
 The `dereferenceVia` URI is particularly important—it tells Ben exactly where to check whether this key is actually registered on GitHub. That verification happens in Tutorial 04.
 
-### Step 5: Add the Attachment to Your XID
+### Step 5: Add Attachment to XID
 
 Now add this payload as an attachment to your XID:
 
@@ -275,7 +343,7 @@ The flags mirror what you used in previous tutorials: `--verify inception` check
 
 Notice the attachment appears with `'vendor': "self"` marking who defined this payload format.
 
-### Step 6: Advance Provenance
+### Step 6: Advance Provenance Mark
 
 When you modify a published XID, you advance the provenance sequence to signal a new version:
 
@@ -306,9 +374,11 @@ This mirrors a realistic workflow. You publish your basic XID first (establishin
 
 The sequence number tells Ben which version he has. If Ben fetches seq 0 but the URL now shows seq 1, he knows an update happened and can re-fetch. Tutorial 04 covers how Ben verifies the provenance sequence he receives.
 
-> **Provenance = Ordering, Not Timestamps**:
+> :book: **Provenance = Ordering, Not Timestamps**:
 >
 > The provenance mark establishes position in a chain starting from genesis. It doesn't prove *when* this happened—just the order. Temporal information comes from external sources: GitHub's server timestamps, signed commits, Ben's own fetch time. Tutorial 04 explores these temporal anchors.
+
+> :brain: **Learn more**: The [Provenance Marks](../concepts/provenance-marks.md) concept doc explains the cryptographic chain structure and how sequence numbers provide ordering guarantees.
 
 ### Step 7: Export and Verify
 
@@ -351,7 +421,7 @@ fi
 
 The attachment survives export—it's part of the public XID that Ben will fetch.
 
-### Step 8: Publish the Updated XID
+### Step 8: Publish Updated XID
 
 Update your publication location with the new version. If you're using a GitHub repository (as BRadvoc8 does), this means committing and pushing:
 
@@ -371,6 +441,10 @@ git push
 
 The signed commit (`-S`) creates another temporal anchor: GitHub will record when this commit was pushed and verify its signature against your registered signing key. This connects your XID publication to your GitHub identity.
 
+> :warning: **Signed Commits Matter**:
+>
+> The `-S` flag signs the commit with your SSH signing key. This creates verifiable evidence that the same key in your XID attestation was used to publish the XID itself. If Ben sees your SSH key in the XID *and* sees that key signing commits to the XID repository, that's stronger evidence than either alone. Without `-S`, you're just claiming to own a key without demonstrating you can use it.
+
 After pushing, the XID is live at your `dereferenceVia` URL. Anyone who fetches it can verify the attestation independently—which is exactly what Ben does in Tutorial 04.
 
 ---
@@ -384,11 +458,32 @@ BRadvoc8 now has verifiable attestations:
 - **Verification pointer** (`dereferenceVia`) to GitHub's API
 - **Signed commit** creating a temporal anchor on GitHub
 
-This is a *self-attestation*—Amira claiming she controls a GitHub account and SSH key. It's not yet *verified*. Ben has the information he needs to check these claims, but the checking happens in Tutorial 04.
+### Trust Assessment
+
+What can be verified now (without external checks):
+
+| Check | Status | What It Proves |
+|-------|--------|----------------|
+| XID signature | ✅ Verifiable | Document integrity, self-consistency |
+| Provenance chain | ✅ Verifiable | Update ordering, version history |
+| Proof-of-control signature | ✅ Verifiable | Key holder signed the claim |
+| Attachment structure | ✅ Verifiable | Data is well-formed |
+
+What requires external verification (Tutorial 04):
+
+| Check | Status | What It Would Prove |
+|-------|--------|---------------------|
+| SSH key on GitHub | ⏳ Not yet checked | Key is actually registered |
+| Signed commits | ⏳ Not yet checked | Key is actively used |
+| GitHub account exists | ⏳ Not yet checked | Account is real |
+
+This is a *self-attestation*—Amira claiming she controls a GitHub account and SSH key. Ben has the information he needs to check these claims, but the checking happens in Tutorial 04.
 
 The trust model is now richer: Tutorial 01 established that BRadvoc8 exists, Tutorial 02 made that existence verifiable and fresh, and now Tutorial 03 offers attestations that connect BRadvoc8 to real-world systems.
 
-## Key Terminology
+> :brain: **Making Stronger Claims**: This tutorial covers *account linkage*—proving you control a GitHub account. For making *skill and capability claims* that are more credible, see [Tutorial 05: Fair Witness Attestations](05-fair-witness-attestations.md), which teaches the methodology of specific, verifiable, evidence-backed claims.
+
+## Appendix: Key Terminology
 
 > **Attachment** - A vendor-qualified container for application-specific data in an XID. Uses `--vendor` to indicate who defined the format.
 >
@@ -404,10 +499,19 @@ The trust model is now richer: Tutorial 01 established that BRadvoc8 exists, Tut
 
 Try these to solidify your understanding:
 
+**Building exercises (Amira's perspective):**
+
 - Generate a new SSH signing key and create a proof-of-control for it.
-- Build an attachment payload with different assertion types (try adding a website or email).
-- Register your SSH signing key on GitHub and verify it appears in the API.
+- Build an attachment payload with different assertion types (try adding a website or email claim).
+- Register your SSH signing key on GitHub and verify it appears in the API at `https://api.github.com/users/YOUR_USERNAME/ssh_signing_keys`.
 - Practice the full workflow: add attachment, advance provenance, export public version.
+
+**Verification exercises (Ben's perspective):**
+
+- Extract the proof-of-control from an attachment and verify its signature.
+- Tamper with a proof (change one character) and confirm verification fails.
+- Compare two versions of an XID with different provenance sequences.
+- Extract the SSH signing key text from an attachment and compare it to GitHub's API response.
 
 ## Example Scripts
 

--- a/tutorials/05-fair-witness-attestations.md
+++ b/tutorials/05-fair-witness-attestations.md
@@ -1,0 +1,449 @@
+# Tutorial 05: Fair Witness Attestations
+
+Build credibility through specific, factual claims that invite verification rather than demand belief.
+
+**Time to complete**: ~15-20 minutes
+**Difficulty**: Intermediate
+**Builds on**: Tutorials 01-04
+
+> **Related Concepts**: After completing this tutorial, explore [Progressive Trust](../concepts/progressive-trust.md) and [Self-Attestation](../concepts/self-attestation.md) to deepen your understanding.
+
+## Prerequisites
+
+- Completed Tutorial 04 (Cross-Verification)
+- The `envelope` CLI tool installed
+- Your XID artifacts from previous tutorials
+
+## What You'll Learn
+
+- The **fair witness methodology** for making credible claims
+- The difference between **detached** and **embedded** attestations
+- How to register **attestation keys** in your XID for signature verification
+- How to create attestations that are **publicly verifiable**
+
+## Building on Tutorial 04
+
+| Tutorial 04 | Tutorial 05 |
+|-------------|-------------|
+| Cross-verified GitHub account | Make broader capability claims |
+| Proved control of external accounts | Create signed attestations |
+| Ben verified account connections | Ben can verify skill claims |
+
+**The Bridge**: Ben verified your GitHub account connection. But controlling an account doesn't prove competence. Now you'll claim what you can actually do.
+
+---
+
+## The Problem: Claims Without Proof
+
+After Tutorial 04, Ben knows BRadvoc8 is a real identity connected to a GitHub account. What he doesn't know is whether BRadvoc8 can write good code, understand security, or deliver quality work. Amira needs to make claims about her capabilities—but vague claims like "Security expert. 8 years experience." are worthless. Anyone can type them.
+
+Amira needs a different approach: specific claims that point to verifiable evidence.
+
+---
+
+## Part I: About Fair Witness Attestations
+
+*This section explains the concepts behind attestations. If you're ready to start creating one, skip to [Part II](#part-ii-creating-a-detached-attestation).*
+
+> :book: **Fair Witness Methodology**: State only what you can personally verify—specific, factual claims that point to observable evidence rather than opinions or vague assertions.
+
+Compare these two claims:
+
+| Claim | Type | Why |
+|-------|------|-----|
+| "I'm good at security" | Weak | Opinion, nothing to check |
+| "I contributed to Galaxy Project (PR #12847)" | Strong | Verifiable on GitHub |
+
+The strong claim invites validation rather than demanding belief. For pseudonymous contributors who can't flash a diploma, evidence-backed claims ARE your credentials.
+
+> :book: **Detached Attestation**: A signed statement that exists as a separate envelope, referencing your XID but not embedded in your XIDDoc.
+
+**Why detached?** Skill claims work better as separate documents. You can share specific attestations with specific people, revoke them independently, and keep your XIDDoc lean. The attestation references your XID identifier, so verifiers can confirm it came from you.
+
+> :brain: **Learn more**: The [Self-Attestation](../concepts/self-attestation.md) concept doc explains the relationship between self-claims and endorsements.
+
+---
+
+## Part II: Creating a Detached Attestation
+
+Amira contributed to Galaxy Project, an open source bioinformatics platform. Her pull request added mass spectrometry visualization features. This is the kind of specific, verifiable claim that builds real credibility.
+
+### Step 0: Verify Dependencies
+
+Ensure you have the required tools installed:
+
+```
+envelope --version
+provenance --version
+
+│ bc-envelope-cli 0.32.0
+│ provenance-mark-cli 0.6.0
+```
+
+If not installed, see Tutorial 01 Step 0 for installation instructions.
+
+### Step 1: Set Up Environment
+
+```
+OUTPUT_DIR="output/xid-tutorial05-$(date +%Y%m%d%H%M%S)"
+mkdir -p "$OUTPUT_DIR"
+
+# Create a fresh XID with provenance tracking
+XID=$(envelope generate keypairs --signing ed25519 | \
+    envelope xid new --nickname "BRadvoc8" --generator include --sign inception)
+
+UNWRAPPED_XID=$(envelope extract wrapped "$XID")
+XID_ID=$(envelope xid id "$UNWRAPPED_XID")
+
+# Generate separate attestation signing keys
+# Best practice: use dedicated keys for attestations, not your XID inception key
+ATTESTATION_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+ATTESTATION_PUBKEYS=$(envelope generate pubkeys "$ATTESTATION_PRVKEYS")
+
+echo "Created XID: $XID_ID"
+
+│ Created XID: c7e764b7
+```
+
+Why separate attestation keys? Your XID inception key is powerful: it can modify your identity. Using it for routine signing increases exposure risk. Attestation keys can be rotated or revoked without affecting your core identity.
+
+> :warning: **Key Separation**: Never use your XID inception key for routine operations. If an attestation key is compromised, you revoke and replace it. If your inception key is compromised, your entire identity is at risk.
+
+> :book: **Attestation Key**: A dedicated signing key for detached attestations, registered in your XID. Ben verifies attestation signatures by checking if the signing key is in BRadvoc8's XIDDoc (see Appendix for key type comparison).
+
+### Step 2: Register Attestation Key in XID
+
+For Ben to verify attestations came from BRadvoc8, the attestation public key must be in the XID. We also embed the private key (encrypted) so Amira can sign attestations without managing separate key files:
+
+```
+# Add attestation keypair to XID (private key encrypted like inception key)
+PASSWORD="your-password-from-previous-tutorials"
+
+XID=$(envelope xid key add \
+    --nickname "attestation-key" \
+    --allow sign \
+    --private encrypt \
+    --encrypt-password "$PASSWORD" \
+    "$ATTESTATION_PRVKEYS" \
+    "$XID")
+
+echo "Added attestation key to XID"
+envelope format "$XID" | grep -A4 "attestation-key"
+
+│ Added attestation key to XID
+│             'nickname': "attestation-key"
+│             'allow': 'Sign'
+│             'privateKey': ENCRYPTED
+```
+
+The CLI derives the public key from the private key automatically. The `--private encrypt` embeds the private key encrypted with your password. The `--allow sign` permission indicates this key can only sign—it cannot modify the XID itself (that requires the inception key).
+
+Now advance provenance to record this change:
+
+```
+# Advance provenance to record the key addition
+XID=$(envelope xid provenance next "$XID")
+
+echo "Provenance advanced"
+PROV_MARK=$(envelope xid provenance get "$XID")
+provenance validate --format json-compact "$PROV_MARK" 2>&1 | grep -o '"end_seq":[0-9]*'
+
+│ Provenance advanced
+│ "end_seq":1
+```
+
+The XID is now at sequence 1: genesis (seq 0) created the identity, this update (seq 1) added the attestation key. Ben can fetch the XID and find the attestation public key to verify signatures.
+
+Export the public version for publication:
+
+```
+# Export public XID (elide private keys and generator)
+PUBLIC_XID=$(envelope xid export --private elide --generator elide "$XID")
+
+echo "Public XID ready for publication"
+envelope format "$PUBLIC_XID" | grep -A1 "attestation-key"
+
+│ Public XID ready for publication
+│             'nickname': "attestation-key"
+│             'allow': 'Sign'
+```
+
+Amira would publish this updated XID at her `dereferenceVia` URL so Ben can fetch it and verify her attestation signatures.
+
+### Step 3: Create the Claim
+
+Start with the claim itself as the envelope subject:
+
+```
+CLAIM=$(envelope subject type string \
+  "I contributed mass spec visualization code to galaxyproject/galaxy (PR #12847, merged 2024)")
+
+envelope format "$CLAIM"
+
+│ "I contributed mass spec visualization code to galaxyproject/galaxy (PR #12847, merged 2024)"
+```
+
+This is just a string. It's not signed, not attributed, not structured. Anyone could create this string.
+
+### Step 4: Add Attestation Metadata
+
+Now add metadata that structures this as a formal attestation:
+
+```
+ATTESTATION=$(envelope assertion add pred-obj known isA string "SelfAttestation" "$CLAIM")
+ATTESTATION=$(envelope assertion add pred-obj string "attestedBy" string "$XID_ID" "$ATTESTATION")
+ATTESTATION=$(envelope assertion add pred-obj string "attestedOn" date "2026-01-21T00:00:00Z" "$ATTESTATION")
+ATTESTATION=$(envelope assertion add pred-obj string "verifiableAt" string "https://github.com/galaxyproject/galaxy/pull/12847" "$ATTESTATION")
+
+envelope format "$ATTESTATION"
+
+│ "I contributed mass spec visualization code to galaxyproject/galaxy (PR #12847, merged 2024)" [
+│     isA: "SelfAttestation"
+│     "attestedBy": "c7e764b7"
+│     "attestedOn": 2026-01-21T00:00:00Z
+│     "verifiableAt": "https://github.com/galaxyproject/galaxy/pull/12847"
+│ ]
+```
+
+Each assertion adds a specific piece of metadata:
+
+| Assertion | Predicate | Value | Purpose |
+|-----------|-----------|-------|---------|
+| 1 | `isA` (known) | `"SelfAttestation"` | Declares this is a self-claim, not an endorsement |
+| 2 | `"attestedBy"` | XID identifier | Links claim to your identity |
+| 3 | `"attestedOn"` | ISO date | Records when you made the claim |
+| 4 | `"verifiableAt"` | URL | Points to evidence for independent verification |
+
+The `isA` assertion marks this as a self-attestation (you claiming something about yourself, as opposed to someone else vouching for you). The `attestedBy` field links to your XID identifier so verifiers know who made the claim. The `attestedOn` timestamp records when you made it. And `verifiableAt` points to the actual evidence: the GitHub PR where anyone can check the code.
+
+> :book: **Self-Attestation**: A claim you make about yourself. Contrast with an *endorsement*, where someone else vouches for you. Self-attestations are starting points; endorsements carry more weight because they come from independent parties.
+
+### Step 5: Sign the Attestation
+
+The attestation is structured but not yet bound to your identity. Anyone could have created it. The signature proves YOU made this claim:
+
+```
+ATTESTATION_SIGNED=$(envelope sign --signer "$ATTESTATION_PRVKEYS" "$ATTESTATION")
+
+envelope format "$ATTESTATION_SIGNED"
+
+│ {
+│     "I contributed mass spec visualization code to galaxyproject/galaxy (PR #12847, merged 2024)" [
+│         isA: "SelfAttestation"
+│         "attestedBy": "c7e764b7"
+│         "attestedOn": 2026-01-21T00:00:00Z
+│         "verifiableAt": "https://github.com/galaxyproject/galaxy/pull/12847"
+│     ]
+│ } [
+│     'signed': Signature
+│ ]
+```
+
+The signature wraps the entire attestation. If anyone modifies any part (the claim, the date, the URL), the signature becomes invalid.
+
+### Step 6: Verify the Attestation
+
+```
+envelope verify --verifier "$ATTESTATION_PUBKEYS" "$ATTESTATION_SIGNED"
+
+│ Signature valid
+```
+
+But wait. You signed it. Does that prove the claim is true?
+
+No. Verification confirms that BRadvoc8's key signed this content and that nothing was modified. It says nothing about whether the claim is accurate. Anyone can claim "I contributed to Galaxy Project." The signature proves you MADE the claim, not that you made the contribution.
+
+This distinction matters. Self-attestations are starting points for building trust, not proof of competence. The `verifiableAt` field points to evidence that verifiers can check independently.
+
+---
+
+## Part III: What Makes This Verifiable
+
+Amira created and signed her attestation. Now we switch to Ben's perspective: how does he verify what she claims?
+
+Ben receives Amira's attestation. His verification has two layers: cryptographic and evidential.
+
+**Cryptographic verification**: Ben fetches BRadvoc8's XID, extracts the attestation key, and verifies the signature:
+
+```
+# Ben fetches BRadvoc8's published XID
+BEN_FETCHED_XID="$PUBLIC_XID"  # In reality, fetched from dereferenceVia URL
+
+# Extract the attestation public key from the XID
+ATTESTATION_KEY=$(envelope xid key all "$BEN_FETCHED_XID" | head -1)
+
+# Verify attestation was signed by that key
+envelope verify --verifier "$ATTESTATION_KEY" "$ATTESTATION_SIGNED"
+
+│ Signature valid
+```
+
+This proves the attestation wasn't tampered with AND came from a key registered in BRadvoc8's XID.
+
+**Evidence verification**: Ben follows the `verifiableAt` URL to GitHub and checks if PR #12847 exists, was merged, and adds mass spec visualization. The attestation points to observable evidence that anyone can independently verify.
+
+Here's the gap: Ben can't prove BRadvoc8 IS the PR author from this attestation alone. What he can see is that BRadvoc8 points to real evidence and invites investigation. Combined with other attestations and eventual peer endorsements, a picture of credibility builds over time.
+
+> :brain: **Learn more**: The [Progressive Trust](../concepts/progressive-trust.md) concept doc explains how self-attestations combine with cross-verification and peer endorsements to build meaningful trust over time.
+
+---
+
+## Part IV: Attestation Lifecycle
+
+Attestations aren't permanent. Claims become stale, projects end, skills evolve. Amira's Galaxy Project contribution from 2024 is factual forever, but her "currently working on" claims need updates.
+
+### Updating vs. Superseding
+
+| Situation | Approach |
+|-----------|----------|
+| Claim is still true, adding detail | Create new attestation with more info |
+| Claim is outdated | Create superseding attestation |
+| Claim was wrong | Create retraction attestation |
+
+Attestations are immutable once signed—you can't edit one. Instead, you create a new attestation that references and supersedes the old one.
+
+### Step 7: Supersede an Attestation
+
+Two years later, Amira's Galaxy Project work has expanded:
+
+```
+# Create superseding attestation
+UPDATED_CLAIM=$(envelope subject type string \
+  "I contributed mass spec visualization and data pipeline code to galaxyproject/galaxy (PRs #12847, #14201, #15892, 2024-2026)")
+
+UPDATED_ATTESTATION=$(envelope assertion add pred-obj known isA string "SelfAttestation" "$UPDATED_CLAIM")
+UPDATED_ATTESTATION=$(envelope assertion add pred-obj string "attestedBy" string "$XID_ID" "$UPDATED_ATTESTATION")
+UPDATED_ATTESTATION=$(envelope assertion add pred-obj string "attestedOn" date "2028-01-15T00:00:00Z" "$UPDATED_ATTESTATION")
+UPDATED_ATTESTATION=$(envelope assertion add pred-obj string "verifiableAt" string "https://github.com/galaxyproject/galaxy/pulls?q=author:BRadvoc8" "$UPDATED_ATTESTATION")
+
+# Reference the original attestation being superseded
+ORIGINAL_DIGEST=$(envelope digest "$ATTESTATION_SIGNED")
+UPDATED_ATTESTATION=$(envelope assertion add pred-obj string "supersedes" string "$ORIGINAL_DIGEST" "$UPDATED_ATTESTATION")
+
+# Sign
+UPDATED_ATTESTATION=$(envelope sign --signer "$ATTESTATION_PRVKEYS" "$UPDATED_ATTESTATION")
+
+echo "Updated attestation (supersedes original):"
+envelope format "$UPDATED_ATTESTATION" | head -12
+
+│ {
+│     "I contributed mass spec visualization and data pipeline code to galaxyproject/galaxy (PRs #12847, #14201, #15892, 2024-2026)" [
+│         'isA': "SelfAttestation"
+│         "attestedBy": "c7e764b7"
+│         "attestedOn": 2028-01-15T00:00:00Z
+│         "supersedes": "ur:digest/hdcx..."
+│         "verifiableAt": "https://github.com/galaxyproject/galaxy/pulls?q=author:BRadvoc8"
+│     ]
+│ } [
+│     'signed': Signature
+│ ]
+```
+
+The `supersedes` field links to the original attestation's digest. Verifiers who encounter both can see the relationship: the newer one extends and replaces the older one.
+
+> :book: **Superseding Pattern**: Create a new attestation with a `supersedes` assertion pointing to the original's digest. The original remains valid (the 2024 claim was true then) but the newer attestation reflects current state.
+
+### Retractions
+
+If a claim was incorrect, create a retraction:
+
+```
+# Retract an incorrect claim
+RETRACTION=$(envelope subject type string "RETRACTED: [original claim text]")
+RETRACTION=$(envelope assertion add pred-obj known isA string "Retraction" "$RETRACTION")
+RETRACTION=$(envelope assertion add pred-obj string "retracts" string "$ORIGINAL_DIGEST" "$RETRACTION")
+RETRACTION=$(envelope assertion add pred-obj string "reason" string "Claim was overstated" "$RETRACTION")
+RETRACTION=$(envelope sign --signer "$ATTESTATION_PRVKEYS" "$RETRACTION")
+```
+
+Retractions are serious—they indicate an error in judgment. Use sparingly. Most updates are supersessions (extending or refining), not retractions (correcting errors).
+
+---
+
+## Part V: Wrap-Up
+
+Amira has created a fair witness attestation signed with a dedicated attestation key registered in her XID. Ben can verify signatures against her XIDDoc and check evidence at the `verifiableAt` URL.
+
+### Save Your Work
+
+```
+echo "$ATTESTATION_SIGNED" > "$OUTPUT_DIR/attestation-galaxy.envelope"
+echo "$XID" > "$OUTPUT_DIR/BRadvoc8-xid.envelope"
+
+echo "Saved to $OUTPUT_DIR"
+ls "$OUTPUT_DIR"
+
+│ Saved to output/xid-tutorial05-20260121120000
+│ attestation-galaxy.envelope
+│ BRadvoc8-xid.envelope
+```
+
+> :brain: **Key Storage**: Your attestation private key is embedded in the XID document, encrypted with your password (just like the inception key). You don't need a separate key file—when you need to sign attestations, you extract the key from your XID using your password.
+
+### What You Built
+
+You created a fair witness attestation: a specific, factual claim that points to verifiable evidence. The Galaxy Project attestation isn't just a claim; it's a claim with a URL where anyone can check the actual code.
+
+**Trust Assessment**:
+
+| What Ben Can Verify | What Remains Unproven |
+|---------------------|----------------------|
+| ✅ BRadvoc8 made this claim | ❓ Claim is actually true |
+| ✅ Claim wasn't modified (signature valid) | ❓ BRadvoc8 = PR author |
+| ✅ Evidence URL exists | ❓ Quality of the contribution |
+| ✅ Attestation date recorded | ❓ Real-world identity |
+
+You learned the difference between detached and embedded attestations, and why detached works better for skill claims. And you understand that signatures prove you made the claim, not that the claim is true. The evidence link is what makes verification possible.
+
+### The Limitation
+
+> :warning: **Self-Attestations Have Limited Weight**: Anyone can claim anything. A signed attestation proves you made the claim, not that it's true. Real credibility comes from peer endorsements and verified collaboration history.
+
+Self-attestations are cheap to create. Anyone can claim anything. What's missing is external validation: when peers vouch for you, your claims gain weight. But not all claims should be published publicly—some credentials could reveal your identity if combined with other public information.
+
+---
+
+## Appendix: Key Terminology
+
+> **Attestation Key**: A dedicated signing key for creating detached attestations, registered in your XID. Verified against the XID key list, not an external service.
+>
+> **Detached Attestation**: A signed statement that exists as a separate envelope, referencing your XID but not embedded in your XIDDoc.
+>
+> **Embedded Attestation**: An assertion inside your XIDDoc, tightly coupled to your identity.
+>
+> **Fair Witness Methodology**: Making only factual, specific, verifiable claims rather than opinions or vague assertions.
+>
+> **Self-Attestation**: A claim you make about yourself, as opposed to an endorsement where someone else vouches for you.
+>
+> **Superseding**: Creating a new attestation that replaces an older one, linked via the `supersedes` assertion. The original remains valid for its time; the new one reflects current state.
+
+### Key Type Comparison
+
+| Key Type | Purpose | Verified Against | Added In |
+|----------|---------|------------------|----------|
+| XID inception key | Signs XID document updates | XID itself | T01 |
+| SSH signing key | Signs Git commits | GitHub's registry | T03 |
+| Attestation key | Signs detached attestations | XID key list | T05 (now) |
+
+---
+
+## Exercises
+
+**Building exercises (Amira's perspective):**
+
+- Create a fair witness attestation for one of your own verifiable contributions (GitHub PR, package, blog post).
+- Register a dedicated attestation key in your XID (not your inception key).
+
+**Verification exercises (Ben's perspective):**
+
+- Given an attestation envelope, extract the `verifiableAt` URL and check if the evidence exists.
+- Verify the signature using the attestation key from the XID.
+
+**Analysis exercises:**
+
+- Compare a fair witness claim to a vague claim about the same skill: what makes the fair witness version stronger?
+- Identify 2-3 public contributions you could attest to with verifiable evidence.
+
+---
+
+**Previous**: [Cross-Verification](04-cross-verification.md) | **Next**: [Managing Sensitive Claims](06-managing-sensitive-claims.md)

--- a/tutorials/06-managing-sensitive-claims.md
+++ b/tutorials/06-managing-sensitive-claims.md
@@ -1,0 +1,371 @@
+# Tutorial 06: Managing Sensitive Claims
+
+Handle credentials that are too risky to publish publicly using commitment patterns and selective disclosure.
+
+**Time to complete**: ~20-25 minutes
+**Difficulty**: Intermediate
+**Builds on**: Tutorials 01-05
+
+> **Related Concepts**: After completing this tutorial, explore [Progressive Trust](../concepts/progressive-trust.md) and [Self-Attestation](../concepts/self-attestation.md) to deepen your understanding.
+
+## Prerequisites
+
+- Completed Tutorial 05 (Fair Witness Attestations)
+- The `envelope` CLI tool installed
+- Understanding of detached attestations from Tutorial 05
+
+## What You'll Learn
+
+- How **correlation risk** compounds with each public claim
+- Three approaches for handling sensitive information
+- **Inclusion proofs**: commit now, reveal later
+- The verifier's workflow for checking revealed claims
+
+## Building on Tutorial 05
+
+| Tutorial 05 | Tutorial 06 |
+|-------------|-------------|
+| Created public attestations | Handle sensitive ones |
+| Galaxy contribution (safe to share) | Crypto audit (risky to share) |
+| Fair witness methodology | Disclosure strategy |
+
+**The Bridge**: Your Galaxy Project attestation is safe to share publicly—it's already on GitHub for anyone to see. But not all your skills pass the newspaper test. What about credentials that could identify you if published?
+
+---
+
+## The Problem: Every Claim Narrows the Field
+
+Amira did cryptographic audit work for a fintech startup in 2023-2024. She reviewed authentication implementations, found vulnerabilities, and helped fix them. It's valuable experience that would strengthen her credibility for security work.
+
+But "crypto auditor" is a rare skill. How many people worldwide have done professional cryptographic audits? Maybe a few thousand. Combine that with her other public claims—Galaxy Project contributor, privacy-focused, speaks Portuguese—and the intersection might describe only a handful of people.
+
+This is correlation risk. Each claim by itself might be safe. Combined, they create a fingerprint.
+
+> :book: **Correlation Risk**: The potential for combining public information to narrow an anonymity set until it identifies a specific person. Each additional claim shrinks the pool of people who could match.
+
+### How Claims Compound
+
+Watch how Amira's anonymity set shrinks:
+
+| Claims Combined | Approximate Population |
+|----------------|------------------------|
+| "Security professional" | Hundreds of thousands |
+| + "8 years experience" | Tens of thousands |
+| + "Privacy focus" | Thousands |
+| + "Crypto audit experience" | Hundreds |
+| + "Galaxy Project contributor" | Maybe dozens |
+| + "Based in South America" | Single digits |
+
+That last combination might describe three people in the world. If an adversary knows those facts and sees BRadvoc8's public profile, correlation becomes trivial.
+
+### The Quick Heuristic
+
+> :warning: **Before Publishing**: Ask "How many people worldwide could truthfully make this exact statement?" If the answer is under 100, combine it with your other public claims and ask again. If the combined answer approaches single digits, that claim needs special handling.
+
+---
+
+## Part I: Three Approaches to Sensitive Information
+
+Amira has three options for her crypto audit experience:
+
+### Option 1: Omit Entirely
+
+Don't mention it at all. If she never needs to prove this experience, keeping it private is the safest choice. Zero correlation risk from information that isn't published.
+
+The downside: she loses the reputation benefit. If crypto audit experience would help her get accepted onto a security project, omitting it means she can't use it.
+
+### Option 2: Commit Elided
+
+Create the attestation, sign it, but publish only an opaque commitment (the digest). The commitment proves she had some claim at a specific time, without revealing what the claim says. Later, she can reveal the full attestation to specific people who can verify it matches the public commitment.
+
+This is the "prove I had it all along" pattern. Useful when you might need to demonstrate timing or existence without revealing content.
+
+### Option 3: Encrypt for Recipient
+
+Create the attestation and encrypt it for a specific person's public key. Only that person can read it. No public trace at all.
+
+This is covered in Tutorial 07. It's the right choice when a specific trusted person needs to see the claim now, and you don't need to prove timing to anyone else.
+
+### When to Use Each
+
+| Situation | Approach |
+|-----------|----------|
+| Never need to prove this | Omit entirely |
+| Might need to prove timing later | Commit elided |
+| Specific person needs it now | Encrypt for them |
+
+Amira decides her crypto audit experience fits the middle category. She might need to prove this capability to future collaborators, but she doesn't want to publish it broadly. She'll commit an elided version publicly and reveal the full attestation selectively.
+
+> :brain: **Learn more**: These three approaches are part of the broader concept of [Selective Disclosure](../concepts/selective-disclosure.md)—the ability to reveal different information to different parties from the same underlying data structure.
+
+---
+
+## Part II: Creating the Commitment
+
+### Step 0: Verify Dependencies
+
+Ensure you have the required tools installed:
+
+```
+envelope --version
+
+│ bc-envelope-cli 0.32.0
+```
+
+If not installed, see Tutorial 01 Step 0 for installation instructions.
+
+### Step 1: Set Up Environment
+
+```
+OUTPUT_DIR="output/xid-tutorial06-$(date +%Y%m%d%H%M%S)"
+mkdir -p "$OUTPUT_DIR"
+
+# Create XID
+XID=$(envelope generate keypairs --signing ed25519 | \
+    envelope xid new --nickname "BRadvoc8" --generator include --sign inception)
+
+UNWRAPPED_XID=$(envelope extract wrapped "$XID")
+XID_ID=$(envelope xid id "$UNWRAPPED_XID")
+
+# Attestation keys
+ATTESTATION_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+ATTESTATION_PUBKEYS=$(envelope generate pubkeys "$ATTESTATION_PRVKEYS")
+
+echo "Created XID: $XID_ID"
+
+│ Created XID: c7e764b7
+```
+
+### Step 2: Create the Sensitive Attestation
+
+Amira creates her crypto audit attestation with fair witness precision:
+
+```
+AUDIT_CLAIM=$(envelope subject type string \
+  "I audited cryptographic implementations for authentication systems (2023-2024)")
+
+AUDIT_CLAIM=$(envelope assertion add pred-obj known isA string "SelfAttestation" "$AUDIT_CLAIM")
+AUDIT_CLAIM=$(envelope assertion add pred-obj string "attestedBy" string "$XID_ID" "$AUDIT_CLAIM")
+AUDIT_CLAIM=$(envelope assertion add pred-obj string "attestedOn" date "2026-01-21T00:00:00Z" "$AUDIT_CLAIM")
+AUDIT_CLAIM=$(envelope assertion add pred-obj string "skillCategory" string "Security" "$AUDIT_CLAIM")
+
+envelope format "$AUDIT_CLAIM"
+
+│ "I audited cryptographic implementations for authentication systems (2023-2024)" [
+│     isA: "SelfAttestation"
+│     "attestedBy": "c7e764b7"
+│     "attestedOn": 2026-01-21T00:00:00Z
+│     "skillCategory": "Security"
+│ ]
+```
+
+Notice she doesn't include the company name or specific details that would make correlation easier. The claim is specific enough to be meaningful but not so detailed that it uniquely identifies her.
+
+### Step 3: Sign the Full Attestation
+
+```
+AUDIT_SIGNED=$(envelope sign --signer "$ATTESTATION_PRVKEYS" "$AUDIT_CLAIM")
+
+echo "Full attestation created and signed"
+envelope format "$AUDIT_SIGNED"
+
+│ Full attestation created and signed
+│ {
+│     "I audited cryptographic implementations for authentication systems (2023-2024)" [
+│         isA: "SelfAttestation"
+│         "attestedBy": "c7e764b7"
+│         "attestedOn": 2026-01-21T00:00:00Z
+│         "skillCategory": "Security"
+│     ]
+│ } [
+│     'signed': Signature
+│ ]
+```
+
+This is the full attestation. Amira keeps this secure—it's the version she'll reveal selectively.
+
+### Step 4: Create the Elided Commitment
+
+Now she creates a version with the content removed but the cryptographic structure preserved:
+
+```
+AUDIT_DIGEST=$(envelope digest "$AUDIT_SIGNED")
+AUDIT_ELIDED=$(envelope elide removing "$AUDIT_DIGEST" "$AUDIT_SIGNED")
+
+echo "Elided commitment created"
+echo "Digest: $AUDIT_DIGEST"
+envelope format "$AUDIT_ELIDED"
+
+│ Elided commitment created
+│ Digest: ur:digest/hdcxzmwnbnrt...
+│ ELIDED
+```
+
+The elided version shows nothing—just `ELIDED`. But here's the key property:
+
+```
+FULL_DIGEST=$(envelope digest "$AUDIT_SIGNED")
+ELIDED_DIGEST=$(envelope digest "$AUDIT_ELIDED")
+
+echo "Full attestation digest:  $FULL_DIGEST"
+echo "Elided version digest:    $ELIDED_DIGEST"
+
+if [ "$FULL_DIGEST" = "$ELIDED_DIGEST" ]; then
+    echo "Digests match!"
+fi
+
+│ Full attestation digest:  ur:digest/hdcxzmwn...
+│ Elided version digest:    ur:digest/hdcxzmwn...
+│ Digests match!
+```
+
+The digests are identical. This is the foundation of the inclusion proof: the elided version has the same cryptographic identity as the full version, even though the content is hidden.
+
+> :brain: **How this works**: Gordian Envelope uses Merkle tree hashing—each part contributes to the root hash, so eliding content preserves the cryptographic identity. See the [Gordian Envelope specification](https://developer.blockchaincommons.com/envelope/) for technical details.
+
+---
+
+## Part III: The Reveal
+
+Six months later, DevReviewer is evaluating Amira for a security collaboration. They've seen her public attestation (Galaxy Project) but want to know about her security audit experience. Amira mentioned she has relevant experience but couldn't share details publicly.
+
+### Step 5: Amira Reveals to DevReviewer
+
+Amira sends DevReviewer the full attestation:
+
+```
+# Amira sends AUDIT_SIGNED to DevReviewer
+echo "Amira sends full attestation to DevReviewer"
+
+│ Amira sends full attestation to DevReviewer
+```
+
+DevReviewer already has the elided commitment (from Amira's public profile or an earlier conversation). Now they have the full version too.
+
+### Step 6: DevReviewer Verifies the Inclusion Proof
+
+DevReviewer's verification has two parts: checking that this is the same document as the commitment, and verifying the signature.
+
+```
+# DevReviewer computes the digest of what they received
+RECEIVED_DIGEST=$(envelope digest "$AUDIT_SIGNED")
+
+# Compare to the known commitment digest
+echo "Commitment digest: $ELIDED_DIGEST"
+echo "Received digest:   $RECEIVED_DIGEST"
+
+if [ "$RECEIVED_DIGEST" = "$ELIDED_DIGEST" ]; then
+    echo "Inclusion proof valid: this matches the public commitment"
+else
+    echo "WARNING: Does not match commitment!"
+fi
+
+│ Commitment digest: ur:digest/hdcxzmwn...
+│ Received digest:   ur:digest/hdcxzmwn...
+│ Inclusion proof valid: this matches the public commitment
+```
+
+The digests match. This proves the full attestation Amira revealed is the same document she committed to earlier—not something she fabricated after the fact.
+
+### Step 7: DevReviewer Verifies the Signature
+
+```
+envelope verify --verifier "$ATTESTATION_PUBKEYS" "$AUDIT_SIGNED"
+
+│ Signature valid
+```
+
+The signature is valid. Combined with the inclusion proof, DevReviewer has three pieces of information: the attestation matches what Amira committed to publicly, BRadvoc8's key signed this content, and the content hasn't been modified since signing. DevReviewer can now read the claim and factor it into their trust decision.
+
+---
+
+## Part IV: What the Elided Version Cannot Do
+
+There's an important limitation to understand. Let's see what the elided version looks like:
+
+```
+envelope format "$AUDIT_ELIDED"
+
+│ ELIDED
+```
+
+Just `ELIDED`. No content, no metadata, no signature visible. What happens if we try to verify it?
+
+```
+envelope verify --verifier "$ATTESTATION_PUBKEYS" "$AUDIT_ELIDED" 2>&1 || true
+
+│ Error: No signature found
+```
+
+The verification fails because the elided version has no signature to check. Remember, we elided the *entire* signed envelope, not just the content inside. The elided version is just a digest placeholder—it proves something with this digest exists, but you can't verify its authenticity without the full version.
+
+This is by design. The commitment pattern separates timing from content: in the commit phase, you publish the elided version to prove when you made the claim; in the reveal phase, you share the full version with specific people to prove what you claimed; then the recipient verifies the revealed version matches the public commitment.
+
+You need the full version to verify the signature. The elided version only proves you had *something*—the full version proves what.
+
+---
+
+## Part V: Wrap-Up
+
+### Save Your Work
+
+```
+# Save attestation files
+echo "$AUDIT_SIGNED" > "$OUTPUT_DIR/audit-attestation-FULL.envelope"
+echo "$AUDIT_ELIDED" > "$OUTPUT_DIR/audit-attestation-ELIDED.envelope"
+echo "$AUDIT_DIGEST" > "$OUTPUT_DIR/audit-digest.txt"
+
+# Save identity files
+echo "$XID" > "$OUTPUT_DIR/BRadvoc8-xid.envelope"
+echo "$ATTESTATION_PRVKEYS" > "$OUTPUT_DIR/attestation-prvkeys.envelope"
+
+echo "Saved to $OUTPUT_DIR:"
+ls "$OUTPUT_DIR"
+
+│ Saved to output/xid-tutorial06-20260121120000:
+│ audit-attestation-ELIDED.envelope
+│ audit-attestation-FULL.envelope
+│ audit-digest.txt
+│ attestation-prvkeys.envelope
+│ BRadvoc8-xid.envelope
+```
+
+### What You Built
+
+You created a sensitive attestation and committed to it publicly without revealing the content. The inclusion proof pattern lets Amira prove she had this credential all along when she chooses to reveal it—she can't be accused of fabricating it after the fact.
+
+You also understand correlation risk: how claims compound to narrow anonymity sets. The three disclosure approaches (omit, commit, encrypt) give you options for different situations.
+
+### The Remaining Gap
+
+The commit-reveal pattern works for proving timing and existence. But what about claims so sensitive that even a hint of their existence is risky? Amira's CivilTrust work falls into this category—she can't even suggest she has human rights technology experience. That requires direct encrypted sharing with specific trusted people.
+
+---
+
+## Appendix: Key Terminology
+
+> **Correlation Risk**: The potential for combining public information to identify a pseudonym. Claims compound: each one narrows the anonymity set.
+>
+> **Inclusion Proof**: Demonstrating that a revealed document matches a previously published commitment (same digest).
+>
+> **Elided Envelope**: An envelope with content removed but cryptographic identity (digest) preserved. Proves existence without revealing content.
+
+### Practical Notes
+
+**When to use commit-reveal**: The pattern makes sense when a claim is too sensitive to publish broadly but you might need to prove timing later. For claims only specific people will ever see, direct encrypted sharing (Tutorial 07) is simpler.
+
+**Public commitment lists**: You might maintain a list of digests in your public profile with category hints (e.g., "Security", "Privacy Engineering"). This tells collaborators you have additional credentials without revealing what they are.
+
+**Refreshing commitments**: If your skills evolve, create new attestations. Old commitments remain valid but can be retired.
+
+---
+
+## Exercises
+
+1. Identify a skill you have that would be risky to publish publicly. What makes it identifying?
+2. Create an elided commitment for a hypothetical sensitive attestation
+3. Walk through the verification steps as if you were DevReviewer receiving a revealed attestation
+
+---
+
+**Previous**: [Fair Witness Attestations](05-fair-witness-attestations.md) | **Next**: [Encrypted Sharing](07-encrypted-sharing.md)

--- a/tutorials/07-encrypted-sharing.md
+++ b/tutorials/07-encrypted-sharing.md
@@ -1,0 +1,323 @@
+# Tutorial 07: Encrypted Sharing
+
+Share sensitive credentials with specific trusted individuals using recipient-specific encryption. The previous tutorial showed how to commit without revealing—this tutorial shows how to share secrets with people you trust.
+
+**Time to complete**: ~15-20 minutes
+**Difficulty**: Intermediate
+**Builds on**: Tutorials 01-06
+
+> **Related Concepts**: After completing this tutorial, explore [Data Minimization](../concepts/data-minimization.md) and [Progressive Trust](../concepts/progressive-trust.md) to deepen your understanding.
+
+## Prerequisites
+
+- Completed Tutorial 05 (Fair Witness Attestations)
+- Completed Tutorial 06 (Managing Sensitive Claims)
+- The `envelope` CLI tool installed
+
+## What You'll Learn
+
+- How to encrypt attestations for specific recipients
+- The difference between elision and encryption
+- When encryption is the right choice over commitment
+
+## Building on Tutorial 06
+
+| Tutorial 06 | Tutorial 07 |
+|-------------|-------------|
+| Committed sensitive claims (elided) | Share secrets with specific trusted people |
+| Proved timing without revealing content | Reveal actual content to recipients |
+| DevReviewer verified crypto audit claim | DevReviewer receives CivilTrust credential |
+
+**The Bridge**: In Tutorial 06, Amira committed her crypto audit experience and later revealed it to DevReviewer. That built trust. Now DevReviewer is evaluating Amira for a security collaboration and wants to see her most sensitive work. The commit-reveal pattern proves timing—but Amira's CivilTrust work is so sensitive she doesn't even want to commit it publicly. She needs to share it directly with DevReviewer and no one else.
+
+---
+
+## The Problem: Some Secrets Can't Even Be Hinted At
+
+Amira designed the authentication system for CivilTrust, a human rights documentation platform. This is exactly the kind of experience that would prove her security credentials. But there's a problem.
+
+CivilTrust maintains a contributor list. If anyone connects BRadvoc8 to CivilTrust contributions, they can look up the legal names of contributors. In certain jurisdictions, being identified as having worked on human rights technology could endanger Amira.
+
+The commit-reveal pattern from Tutorial 06 won't work here. Even an elided commitment is a publication—it proves she has *some* sensitive security credential. An adversary monitoring her profile might investigate what that commitment hides. For CivilTrust, she needs zero public trace.
+
+The solution is encrypted sharing: encrypt the attestation so only DevReviewer can read it. No public commitment, no hint of existence, just a private message between two people who trust each other.
+
+---
+
+## Part I: Setting Up for Encryption
+
+### Step 0: Verify Dependencies
+
+Ensure you have the required tools installed:
+
+```
+envelope --version
+
+│ bc-envelope-cli 0.32.0
+```
+
+If not installed, see Tutorial 01 Step 0 for installation instructions.
+
+### Step 1: Establish Identities
+
+```
+OUTPUT_DIR="output/xid-tutorial07-$(date +%Y%m%d%H%M%S)"
+mkdir -p "$OUTPUT_DIR"
+
+# Amira's XID with provenance tracking
+XID=$(envelope generate keypairs --signing ed25519 | \
+    envelope xid new --nickname "BRadvoc8" --generator include --sign inception)
+
+UNWRAPPED_XID=$(envelope extract wrapped "$XID")
+XID_ID=$(envelope xid id "$UNWRAPPED_XID")
+
+# Generate separate attestation signing keys
+ATTESTATION_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+ATTESTATION_PUBKEYS=$(envelope generate pubkeys "$ATTESTATION_PRVKEYS")
+
+echo "Amira's XID: $XID_ID"
+
+│ Amira's XID: c7e764b7
+```
+
+### Step 2: DevReviewer Creates Keys for Receiving
+
+DevReviewer needs keys to receive encrypted data. They share their public key with Amira:
+
+```
+# DevReviewer generates keypair for receiving encrypted content
+DEVREVIEWER_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+DEVREVIEWER_PUBKEYS=$(envelope generate pubkeys "$DEVREVIEWER_PRVKEYS")
+
+echo "DevReviewer's public key ready to receive encrypted data"
+
+│ DevReviewer's public key ready to receive encrypted data
+```
+
+In practice, DevReviewer would share their public key through a secure channel—perhaps in their own XIDDoc, or via direct message from their earlier interactions in Tutorial 06.
+
+> :brain: **Key Exchange**: For real-world use, recipients publish their public keys in their XIDDoc. Amira would fetch DevReviewer's XID and extract the encryption key, just as Ben extracted keys for verification in Tutorial 04.
+
+---
+
+## Part II: Creating the Sensitive Attestation
+
+### Step 3: Amira Creates Her CivilTrust Claim
+
+This claim would reveal her legal identity if published:
+
+```
+CIVILTRUST_CLAIM=$(envelope subject type string \
+  "I designed the authentication system for CivilTrust human rights documentation platform (2024)")
+
+CIVILTRUST_ATTESTATION=$(envelope assertion add pred-obj known isA string "SelfAttestation" "$CIVILTRUST_CLAIM")
+CIVILTRUST_ATTESTATION=$(envelope assertion add pred-obj string "attestedBy" string "$XID_ID" "$CIVILTRUST_ATTESTATION")
+CIVILTRUST_ATTESTATION=$(envelope assertion add pred-obj string "attestedOn" date "2026-01-21T00:00:00Z" "$CIVILTRUST_ATTESTATION")
+CIVILTRUST_ATTESTATION=$(envelope assertion add pred-obj string "privacyRisk" string "Links to legal identity via contributor list" "$CIVILTRUST_ATTESTATION")
+
+# Sign first (proves authenticity)
+CIVILTRUST_SIGNED=$(envelope sign --signer "$ATTESTATION_PRVKEYS" "$CIVILTRUST_ATTESTATION")
+
+echo "Attestation (before encryption):"
+envelope format "$CIVILTRUST_SIGNED"
+
+│ {
+│     "I designed the authentication system for CivilTrust human rights documentation platform (2024)" [
+│         isA: "SelfAttestation"
+│         "attestedBy": "c7e764b7"
+│         "attestedOn": 2026-01-21T00:00:00Z
+│         "privacyRisk": "Links to legal identity via contributor list"
+│     ]
+│ } [
+│     'signed': Signature
+│ ]
+```
+
+The `privacyRisk` field documents why this claim is sensitive—a reminder to herself and a signal to DevReviewer about the trust she's placing in them.
+
+### Step 4: Encrypt for DevReviewer
+
+```
+CIVILTRUST_ENCRYPTED=$(envelope encrypt --recipient "$DEVREVIEWER_PUBKEYS" "$CIVILTRUST_SIGNED")
+
+echo "Encrypted attestation (only DevReviewer can decrypt):"
+envelope format "$CIVILTRUST_ENCRYPTED"
+
+│ ENCRYPTED [
+│     'isA': "SelfAttestation"
+│     "attestedBy": "c7e764b7"
+│     "attestedOn": 2026-01-21T00:00:00Z
+│     "privacyRisk": "Links to legal identity via contributor list"
+│     'hasRecipient': SealedMessage
+│     'signed': Signature
+│ ]
+```
+
+The subject (the actual claim text) is now `ENCRYPTED`, but notice the assertions are still visible. This is important: encryption hides the *content* but not the *structure*. Someone intercepting this can see it's a "SelfAttestation" from BRadvoc8 with a privacy risk note, but they can't read what the actual claim says.
+
+> :warning: **Metadata Leakage**: Encryption hides content but not structure. An observer can see this is a "SelfAttestation" with a "privacyRisk" field—they just can't read the actual claim. For maximum privacy, encrypt the entire envelope including assertions.
+
+The `hasRecipient: SealedMessage` indicates someone can decrypt this envelope. It doesn't reveal *who*—that information is sealed inside the encrypted recipient blob.
+
+---
+
+## Part III: DevReviewer Receives and Verifies
+
+### Step 5: DevReviewer Decrypts
+
+```
+CIVILTRUST_DECRYPTED=$(envelope decrypt --recipient "$DEVREVIEWER_PRVKEYS" "$CIVILTRUST_ENCRYPTED")
+
+echo "DevReviewer sees after decryption:"
+envelope format "$CIVILTRUST_DECRYPTED"
+
+│ {
+│     "I designed the authentication system for CivilTrust human rights documentation platform (2024)" [
+│         isA: "SelfAttestation"
+│         "attestedBy": "c7e764b7"
+│         "attestedOn": 2026-01-21T00:00:00Z
+│         "privacyRisk": "Links to legal identity via contributor list"
+│     ]
+│ } [
+│     'signed': Signature
+│ ]
+```
+
+DevReviewer can now read the full claim. They see that Amira designed the authentication system for CivilTrust—significant security work on a real platform.
+
+### Step 6: DevReviewer Verifies the Signature
+
+```
+envelope verify --verifier "$ATTESTATION_PUBKEYS" "$CIVILTRUST_DECRYPTED"
+
+│ Signature valid
+```
+
+DevReviewer now has what they need: the claim itself (Amira designed CivilTrust authentication), proof of authenticity (the signature matches BRadvoc8's key), and an implicit trust signal—Amira shared information that could harm her if misused.
+
+That last point matters. By sharing this credential, Amira demonstrated that she trusts DevReviewer enough to give them information that could endanger her if misused. This builds the relationship for the peer endorsement that comes next.
+
+### What If Someone Else Intercepts?
+
+```
+# Charlie generates his own keys
+CHARLIE_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+
+# Charlie tries to decrypt
+envelope decrypt --recipient "$CHARLIE_PRVKEYS" "$CIVILTRUST_ENCRYPTED" 2>&1 || true
+
+│ Error: No matching recipient found
+```
+
+Decryption fails cleanly. Charlie can see an encrypted envelope exists and its metadata (that it's a "SelfAttestation" with a privacy risk), but can't read the actual claim text.
+
+---
+
+## Part IV: Elision vs Encryption
+
+Both techniques hide information, but they serve different purposes:
+
+| Aspect | Elision (T06) | Encryption (T07) |
+|--------|---------------|------------------|
+| **Public trace** | Yes (elided digest visible) | No (completely hidden) |
+| **Proves timing** | Yes (commitment exists) | No (no public record) |
+| **Who can see** | No one (until revealed) | Specific recipients only |
+| **Use case** | "Might need to prove later" | "Only this person should see" |
+
+### Choosing Between Them
+
+Use the **commit-reveal pattern** (T06) when you might need to prove you had a credential at a specific time. The elided commitment is public—it proves timing without revealing content.
+
+Use **encryption** (T07) when even the existence of a credential is sensitive. Amira's crypto audit experience could be committed publicly (the category isn't dangerous). Her CivilTrust work can't—even hinting she has human rights tech credentials could draw unwanted attention.
+
+### Sign-Then-Encrypt
+
+Amira signed her attestation *before* encrypting it. This order matters: signing first proves she authored the content, while encrypting second protects that content during transit.
+
+> :book: **Sign-Then-Encrypt**: Always sign content before encrypting. The recipient can then verify authenticity after decryption. The reverse (encrypt-then-sign) only proves who sealed the box, not who created the contents.
+
+> :brain: **Cryptographic foundations**: Gordian Envelope uses X25519 for key encapsulation and IETF ChaCha20-Poly1305 for symmetric encryption. See the [Envelope Encryption spec](https://developer.blockchaincommons.com/envelope/) for technical details.
+
+---
+
+## Part V: Wrap-Up
+
+### Save Your Work
+
+```
+echo "$CIVILTRUST_ENCRYPTED" > "$OUTPUT_DIR/civiltrust-for-devreviewer.envelope"
+echo "$XID" > "$OUTPUT_DIR/BRadvoc8-xid.envelope"
+echo "$ATTESTATION_PRVKEYS" > "$OUTPUT_DIR/attestation-prvkeys.envelope"
+
+echo "Saved to $OUTPUT_DIR"
+ls "$OUTPUT_DIR"
+
+│ Saved to output/xid-tutorial07-20260121120000
+│ attestation-prvkeys.envelope
+│ BRadvoc8-xid.envelope
+│ civiltrust-for-devreviewer.envelope
+```
+
+### What You Built
+
+You now have encrypted sharing: the ability to share sensitive credentials with specific trusted individuals without any public trace. DevReviewer can decrypt and verify Amira's CivilTrust claim, but no one else can read the content or even know it exists.
+
+Combined with the commit-reveal pattern from Tutorial 06, Amira has a complete toolkit for managing sensitive credentials:
+
+| Credential | Approach | Why |
+|------------|----------|-----|
+| Galaxy Project | Public attestation | Already public on GitHub |
+| Crypto audit | Commit elided | Valuable but rare skill |
+| CivilTrust | Encrypt for DevReviewer | Too dangerous for any public trace |
+
+### What Comes Next
+
+DevReviewer has now verified Amira's sensitive credentials. They've seen her crypto audit experience (revealed from commitment) and her CivilTrust work (decrypted). Combined with her public attestations, DevReviewer has a comprehensive picture of BRadvoc8's capabilities.
+
+This is the foundation for the next step: DevReviewer can now vouch for Amira publicly. When peers endorse your work, claims transform into reputation.
+
+---
+
+## Appendix: Key Terminology
+
+> **Encrypted Sharing**: Sharing secrets with specific trusted people using recipient-specific encryption (distinct from elision, which hides from everyone).
+>
+> **Sign-Then-Encrypt**: The practice of signing content before encrypting, so the recipient can verify the signature after decryption.
+>
+> **Trust Signal**: Implicit information conveyed by an action—sharing sensitive data signals trust in the recipient.
+
+---
+
+## Common Questions
+
+### Q: Can I encrypt for multiple recipients at once?
+
+**A:** Yes. Use `--recipient` multiple times: `envelope encrypt --recipient "$ALICE" --recipient "$BOB" "$CONTENT"`. Each recipient can decrypt independently with their own private key. The content is encrypted once with a symmetric key, and that symmetric key is sealed for each recipient separately.
+
+### Q: What if I lose track of who I encrypted something for?
+
+**A:** The envelope shows `'hasRecipient': SealedMessage` for each recipient, but doesn't reveal who they are. Keep your own records of who received what. If you're encrypting for many recipients, consider adding a (non-sensitive) manifest as a separate assertion.
+
+### Q: Should I always encrypt assertions too, or just the subject?
+
+**A:** It depends on your threat model. Basic encryption (shown in this tutorial) hides the subject but leaves assertion predicates visible. For maximum privacy, encrypt the entire envelope including assertions before adding recipient information. The trade-off is that recipients lose structural context.
+
+### Q: Can DevReviewer prove to others that Amira sent this?
+
+**A:** Not cryptographically—the signature proves Amira authored the content, but DevReviewer can't prove they didn't forge the envelope. For transferable proof, Amira would need to sign a statement that includes DevReviewer's identity or use a public commitment. This is by design: encrypted sharing is for private trust, not public proof.
+
+---
+
+## Exercises
+
+1. Create a sensitive attestation and encrypt it for a fictional recipient
+2. Try encrypting for multiple recipients:
+   ```
+   envelope encrypt --recipient "$ALICE_PUBKEYS" --recipient "$BOB_PUBKEYS" "$SIGNED_CLAIM"
+   ```
+   Each recipient can decrypt independently.
+3. Compare `envelope format` output for elided vs encrypted envelopes—what can an observer learn from each?
+
+---
+
+**Previous**: [Managing Sensitive Claims](06-managing-sensitive-claims.md) | **Next**: [Peer Endorsements](08-peer-endorsements.md)

--- a/tutorials/08-peer-endorsements.md
+++ b/tutorials/08-peer-endorsements.md
@@ -1,0 +1,529 @@
+# Tutorial 08: Peer Endorsements
+
+Transform "I say I'm good" into "others agree I'm good" through peer endorsements. Learn to request, give, and verify endorsements that create a web of trust around pseudonymous identities.
+
+**Time to complete**: ~30-35 minutes
+**Difficulty**: Intermediate
+**Builds on**: Tutorials 01-07
+
+> **Related Concepts**: After completing this tutorial, explore [Web of Trust](../concepts/web-of-trust.md) and [Progressive Trust](../concepts/progressive-trust.md) to deepen your understanding.
+
+## Prerequisites
+
+- Completed Tutorial 05 (Fair Witness Attestations)
+- Completed Tutorial 06 (Managing Sensitive Claims)
+- Completed Tutorial 07 (Encrypted Sharing)
+- The `envelope` CLI tool installed
+
+## What You'll Learn
+
+- The difference between attestations (your claims) and endorsements (others' validation)
+- **How to give endorsements** using fair witness methodology
+- How to request and verify endorsements cryptographically
+- How to build a **web of trust** through multiple independent endorsers
+- How **relationship transparency** makes endorsements more valuable
+
+## Building on Tutorial 07
+
+| Tutorial 07 | Tutorial 08 |
+|-------------|-------------|
+| Shared sensitive credentials with DevReviewer | Get public validation from peers |
+| One-to-one trust | Many-to-one trust network |
+| Amira proves to specific person | Others vouch for Amira publicly |
+
+**The Bridge**: In Tutorial 07, Amira shared her CivilTrust credential with DevReviewer privately. DevReviewer now has a complete picture: they've verified her crypto audit experience (T06) and seen her sensitive human rights work (T07). But that only proves things to DevReviewer. For broader reputation, Amira needs public endorsements—DevReviewer and others vouching for her openly.
+
+---
+
+## Amira's Challenge: Getting Validated
+
+Amira has self-attestations about her skills, and she's shared sensitive credentials with Ben. But there's a fundamental limitation:
+
+**Self-attestations only prove you MADE the claim—not that it's true.**
+
+Anyone can claim "8 years of security experience." Project managers evaluating contributors need more than claims—they need validation from people who have actually worked with BRadvoc8.
+
+**The solution**: Peer endorsements. When Charlene (who knows Amira's values) and code reviewers (who've seen her work) vouch for her, it transforms unverified claims into validated reputation.
+
+The key distinction is whose keys sign the statement. Attestations are signed with *your* keys—they prove you made the claim. Endorsements are signed with *their* keys—they stake their reputation on you. That's why endorsements carry more weight: the endorser has something to lose if you turn out to be a fraud.
+
+---
+
+## Part I: Giving Good Endorsements
+
+Endorsing someone is a responsibility—Charlene is staking her own reputation on BRadvoc8. Before creating an endorsement, she works through five questions:
+
+1. **What have I actually observed?** She's seen BRadvoc8's commitment to privacy work over two years—that's endorsable. "Probably a great coder" would be speculation.
+2. **What's the right scope?** "I endorse everything about BRadvoc8" isn't credible. "I endorse her character and values" is specific and honest.
+3. **How do I disclose the relationship?** "Personal friend who introduced her to RISK network" lets evaluators calibrate for potential bias.
+4. **What can't I speak to?** She hasn't seen Amira's code. Acknowledging this makes the endorsement more credible, not less.
+5. **Would I be embarrassed if wrong?** If BRadvoc8 turns out badly, would this endorsement look foolish? If yes, narrow the scope.
+
+> :book: **Fair Witness Endorsement**: State only what you've personally observed. Specific scope + relationship disclosure + acknowledged limitations = credible endorsement.
+
+Charlene's endorsement will be limited to character and values—that's what she can honestly attest to.
+
+---
+
+## Part II: Creating Endorsements
+
+### Step 0: Verify Dependencies
+
+Ensure you have the required tools installed:
+
+```
+envelope --version
+
+│ bc-envelope-cli 0.32.0
+```
+
+If not installed, see Tutorial 01 Step 0 for installation instructions.
+
+### Step 1: Set Up Environment
+
+```
+OUTPUT_DIR="output/xid-tutorial08-$(date +%Y%m%d%H%M%S)"
+mkdir -p "$OUTPUT_DIR"
+
+# Create Amira's XID with provenance tracking
+XID=$(envelope generate keypairs --signing ed25519 | \
+    envelope xid new --nickname "BRadvoc8" --generator include --sign inception)
+
+UNWRAPPED_XID=$(envelope extract wrapped "$XID")
+XID_ID=$(envelope xid id "$UNWRAPPED_XID")
+
+# Generate separate signing keys for Amira's attestations
+XID_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+XID_PUBKEYS=$(envelope generate pubkeys "$XID_PRVKEYS")
+
+echo "Created Amira's XID: $XID_ID"
+
+│ Created Amira's XID: ur:xid/hdcxhsktlbjzhspyfzhl...
+```
+
+### Step 2: Create Charlene's Identity
+
+Before Charlene can endorse BRadvoc8, she needs her own XID:
+
+```
+# Generate Charlene's keys
+CHARLENE_PRVKEYS=$(envelope generate keypairs --signing ed25519)
+CHARLENE_PUBKEYS=$(envelope generate pubkeys "$CHARLENE_PRVKEYS")
+
+# Create Charlene's XID
+CHARLENE_XID=$(envelope xid new --nickname "Charlene" "$CHARLENE_PUBKEYS")
+CHARLENE_XID_ID=$(envelope xid id "$CHARLENE_XID")
+
+echo "Charlene's XID created: $CHARLENE_XID_ID"
+
+│ Charlene's XID created: ur:xid/hdcxdimkatoyis...
+```
+
+### Step 3: Charlene Creates Her Endorsement
+
+Charlene applies fair witness principles to create a character endorsement:
+
+```
+# Create the endorsement subject
+ENDORSEMENT=$(envelope subject type string "BRadvoc8 is a thoughtful and committed contributor to privacy work that protects vulnerable communities")
+
+# Add endorsement metadata
+ENDORSEMENT=$(envelope assertion add pred-obj known isA string "PeerEndorsement" "$ENDORSEMENT")
+ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedBy" string "Charlene" "$ENDORSEMENT")
+ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedOn" date "2026-01-21T00:00:00Z" "$ENDORSEMENT")
+ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementTarget" string "$XID_ID" "$ENDORSEMENT")
+
+# Add relationship context (critical for credibility)
+ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementContext" string "Personal friend, observed values and commitment over 2+ years" "$ENDORSEMENT")
+ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementScope" string "Character and values alignment, not technical skills" "$ENDORSEMENT")
+ENDORSEMENT=$(envelope assertion add pred-obj string "relationshipBasis" string "Friend who introduced BRadvoc8 to RISK network concept" "$ENDORSEMENT")
+
+# Charlene signs with her private key
+CHARLENE_ENDORSEMENT=$(envelope sign --signer "$CHARLENE_PRVKEYS" "$ENDORSEMENT")
+
+echo "Charlene's endorsement:"
+envelope format "$CHARLENE_ENDORSEMENT"
+
+│ "BRadvoc8 is a thoughtful and committed contributor to privacy work that protects vulnerable communities" [
+│     'isA': "PeerEndorsement"
+│     "endorsedBy": "Charlene"
+│     "endorsedOn": 2026-01-21T00:00:00Z
+│     "endorsementContext": "Personal friend, observed values and commitment over 2+ years"
+│     "endorsementScope": "Character and values alignment, not technical skills"
+│     "endorsementTarget": "ur:xid/hdcx..."
+│     "relationshipBasis": "Friend who introduced BRadvoc8 to RISK network concept"
+│     'signed': Signature
+│ ]
+```
+
+Notice how the `endorsementScope` explicitly states what Charlene is NOT endorsing. This honesty makes the endorsement more credible, not less.
+
+### Why Relationship Transparency Matters
+
+The `relationshipBasis` assertion is one of the most valuable parts of this endorsement. When someone reads "Charlene endorses BRadvoc8," they immediately wonder: How well does Charlene know BRadvoc8? What's her basis for judgment? Is there bias?
+
+Consider two versions of the same endorsement. The weak version says only "I endorse BRadvoc8"—the evaluator doesn't know the relationship basis, can't assess potential bias, and has little reason to trust the statement. The strong version says "I endorse BRadvoc8's character. Relationship: friend for 2+ years, observed commitment to privacy work." Now the evaluator has something to work with: length of relationship, what was actually observed, and honest acknowledgment of the friendship.
+
+Endorsement value comes from context. Without relationship transparency, even strong endorsements lose credibility. A stranger's "great work!" means nothing; a code reviewer's "I merged 8 of her PRs and they were all solid" means everything.
+
+### Step 4: Verify Charlene's Endorsement
+
+```
+envelope verify --verifier "$CHARLENE_PUBKEYS" "$CHARLENE_ENDORSEMENT"
+
+│ Signature valid
+```
+
+The verified signature proves this endorsement was signed by Charlene and hasn't been modified. But wait—why is this more trustworthy than Amira's self-attestations?
+
+The difference is cost. Charlene is an independent party staking her own reputation on BRadvoc8. If BRadvoc8 turns out to be incompetent or dishonest, Charlene looks bad for vouching. That reputational risk makes her endorsement a costly signal—she wouldn't make it unless she believed it. Self-attestations cost nothing; endorsements cost credibility.
+
+---
+
+## Part III: Technical Endorsements
+
+Character endorsements establish values alignment, but technical endorsements validate actual skills. Let's add endorsements from people who've worked with BRadvoc8's code.
+
+### Step 5: DevReviewer's Endorsement
+
+DevReviewer has worked with BRadvoc8 across Tutorials 06 and 07. They verified her crypto audit experience through the commit-reveal pattern, then received her sensitive CivilTrust credential via encrypted sharing. Now they're ready to endorse her publicly—staking their own reputation on what they've observed:
+
+```
+# Create reviewer's identity
+REVIEWER_PRVKEYS=$(envelope generate keypairs --signing ed25519)
+REVIEWER_PUBKEYS=$(envelope generate pubkeys "$REVIEWER_PRVKEYS")
+REVIEWER_XID=$(envelope xid new --nickname "DevReviewer" "$REVIEWER_PUBKEYS")
+REVIEWER_XID_ID=$(envelope xid id "$REVIEWER_XID")
+
+# Create technical endorsement
+TECH_ENDORSEMENT=$(envelope subject type string "BRadvoc8 writes secure, well-tested code with clear attention to privacy-preserving patterns")
+
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj known isA string "PeerEndorsement" "$TECH_ENDORSEMENT")
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedBy" string "DevReviewer" "$TECH_ENDORSEMENT")
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedOn" date "2026-01-21T00:00:00Z" "$TECH_ENDORSEMENT")
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementTarget" string "$XID_ID" "$TECH_ENDORSEMENT")
+
+# Technical context
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementContext" string "Verified crypto audit experience, reviewed CivilTrust authentication design" "$TECH_ENDORSEMENT")
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementScope" string "Security architecture, cryptographic implementation, privacy patterns" "$TECH_ENDORSEMENT")
+TECH_ENDORSEMENT=$(envelope assertion add pred-obj string "relationshipBasis" string "Security collaboration partner who verified credentials through commit-reveal and encrypted sharing" "$TECH_ENDORSEMENT")
+
+# Sign
+TECH_ENDORSEMENT_SIGNED=$(envelope sign --signer "$REVIEWER_PRVKEYS" "$TECH_ENDORSEMENT")
+
+echo "Technical endorsement:"
+envelope format "$TECH_ENDORSEMENT_SIGNED"
+
+│ "BRadvoc8 writes secure, well-tested code with clear attention to privacy-preserving patterns" [
+│     'isA': "PeerEndorsement"
+│     "endorsedBy": "DevReviewer"
+│     "endorsedOn": 2026-01-21T00:00:00Z
+│     "endorsementContext": "Verified crypto audit experience, reviewed CivilTrust authentication design"
+│     "endorsementScope": "Security architecture, cryptographic implementation, privacy patterns"
+│     "endorsementTarget": "ur:xid/hdcx..."
+│     "relationshipBasis": "Security collaboration partner who verified credentials through commit-reveal and encrypted sharing"
+│     'signed': Signature
+│ ]
+```
+
+### Step 6: Project Maintainer Endorsement
+
+A maintainer who has merged BRadvoc8's contributions can speak to collaboration quality:
+
+```
+# Create maintainer's identity
+MAINTAINER_PRVKEYS=$(envelope generate keypairs --signing ed25519)
+MAINTAINER_PUBKEYS=$(envelope generate pubkeys "$MAINTAINER_PRVKEYS")
+MAINTAINER_XID=$(envelope xid new --nickname "SecurityMaintainer" "$MAINTAINER_PUBKEYS")
+MAINTAINER_XID_ID=$(envelope xid id "$MAINTAINER_XID")
+
+# Create collaboration endorsement
+COLLAB_ENDORSEMENT=$(envelope subject type string "BRadvoc8 is a reliable contributor who delivers high-quality security enhancements and responds constructively to feedback")
+
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj known isA string "PeerEndorsement" "$COLLAB_ENDORSEMENT")
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedBy" string "SecurityMaintainer" "$COLLAB_ENDORSEMENT")
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedOn" date "2026-01-21T00:00:00Z" "$COLLAB_ENDORSEMENT")
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementTarget" string "$XID_ID" "$COLLAB_ENDORSEMENT")
+
+# Collaboration context
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementContext" string "Collaborated on 3 security features over 6 months" "$COLLAB_ENDORSEMENT")
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsementScope" string "Technical skills, collaboration quality, communication" "$COLLAB_ENDORSEMENT")
+COLLAB_ENDORSEMENT=$(envelope assertion add pred-obj string "relationshipBasis" string "Project maintainer who merged BRadvoc8's contributions" "$COLLAB_ENDORSEMENT")
+
+# Sign
+COLLAB_ENDORSEMENT_SIGNED=$(envelope sign --signer "$MAINTAINER_PRVKEYS" "$COLLAB_ENDORSEMENT")
+
+echo "Collaboration endorsement:"
+envelope format "$COLLAB_ENDORSEMENT_SIGNED"
+
+│ "BRadvoc8 is a reliable contributor who delivers high-quality security enhancements and responds constructively to feedback" [
+│     'isA': "PeerEndorsement"
+│     "endorsedBy": "SecurityMaintainer"
+│     "endorsedOn": 2026-01-21T00:00:00Z
+│     "endorsementContext": "Collaborated on 3 security features over 6 months"
+│     "endorsementScope": "Technical skills, collaboration quality, communication"
+│     "endorsementTarget": "ur:xid/hdcx..."
+│     "relationshipBasis": "Project maintainer who merged BRadvoc8's contributions"
+│     'signed': Signature
+│ ]
+```
+
+### Step 7: Verify All Endorsements
+
+```
+echo "Verifying endorsement chain:"
+echo "============================"
+
+echo "1. Charlene (character):"
+envelope verify --verifier "$CHARLENE_PUBKEYS" "$CHARLENE_ENDORSEMENT"
+
+echo "2. DevReviewer (technical):"
+envelope verify --verifier "$REVIEWER_PUBKEYS" "$TECH_ENDORSEMENT_SIGNED"
+
+echo "3. SecurityMaintainer (collaboration):"
+envelope verify --verifier "$MAINTAINER_PUBKEYS" "$COLLAB_ENDORSEMENT_SIGNED"
+
+echo "============================"
+echo "All endorsements verified"
+
+│ Verifying endorsement chain:
+│ ============================
+│ 1. Charlene (character):
+│ Signature valid
+│ 2. DevReviewer (technical):
+│ Signature valid
+│ 3. SecurityMaintainer (collaboration):
+│ Signature valid
+│ ============================
+│ All endorsements verified
+```
+
+### What If Someone Forges an Endorsement?
+
+What happens if someone creates a fake endorsement claiming Charlene endorsed them?
+
+```
+# Attacker creates fake endorsement
+FAKE_ENDORSEMENT=$(envelope subject type string "BRadvoc8 is amazing at everything")
+FAKE_ENDORSEMENT=$(envelope assertion add pred-obj string "endorsedBy" string "Charlene" "$FAKE_ENDORSEMENT")
+
+# Attacker signs with their own key (not Charlene's)
+ATTACKER_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+FAKE_SIGNED=$(envelope sign --signer "$ATTACKER_PRVKEYS" "$FAKE_ENDORSEMENT")
+
+# Verification against Charlene's real public key fails
+envelope verify --verifier "$CHARLENE_PUBKEYS" "$FAKE_SIGNED"
+
+│ Error: Signature verification failed
+```
+
+The forgery fails because the attacker can't produce a valid signature without Charlene's private key. Anyone can *claim* "endorsedBy: Charlene" in the metadata, but only the cryptographic signature proves authenticity—and that requires Charlene's actual key.
+
+---
+
+## Part IV: Understanding the Web of Trust
+
+BRadvoc8 now has three endorsements from different contexts:
+
+| Endorser | Type | Relationship | Scope |
+|----------|------|--------------|-------|
+| Charlene | Character | Friend (2+ years) | Values, commitment |
+| DevReviewer | Technical | Security collaboration (T06-T07) | Security architecture, crypto |
+| SecurityMaintainer | Collaboration | Project maintainer (6 months) | Technical skills, communication |
+
+### Trust Multiplication
+
+| Endorsements | Trust Level | Why |
+|--------------|-------------|-----|
+| 1 | Weak | Could be a friend doing a favor |
+| 3 independent | Moderate | Pattern of validation |
+| 3 from different contexts | Strong | Triangulated trust |
+
+### Evaluating Endorser Credibility
+
+Quality matters more than quantity. Three endorsements from unknown people don't equal a strong reputation. Three from established community members with clear context is a strong signal.
+
+> :warning: **Endorsement Quality**: "BRadvoc8 is great!" with no context has low value. "I reviewed 8 of her PRs and they were all high quality" with specific evidence has high value. Reputation is recursive—endorsements are only as valuable as the endorsers' own reputations.
+
+### The Bootstrapping Problem
+
+But wait—how does Ben know that "Charlene" is actually Charlene? He verified the signature matches Charlene's public key, but how does he know that key belongs to a trustworthy person named Charlene?
+
+This is the bootstrapping problem of any trust network. The signature proves the endorsement came from *whoever controls that key*. It doesn't prove that person is who they claim to be. Solutions include: Charlene's XID has its own endorsements from people Ben already trusts; Charlene has a history of public contributions Ben can evaluate; or Ben met Charlene through a channel he trusts (a project, a conference, a mutual contact). Trust has to start somewhere—the web of trust makes it *transferable*, not *automatic*.
+
+> :brain: **Historical context**: The "web of trust" concept originated with PGP in the 1990s. XIDs build on this foundation with modern cryptography and portable documents. See [Web of Trust](../concepts/web-of-trust.md) for how the model has evolved.
+
+### The Discovery Challenge
+
+Related to bootstrapping: how does Ben find BRadvoc8 in the first place? In these tutorials, Amira sends Ben her XID URL directly. But in a larger ecosystem, Ben might want to search for "security contributors who've worked on privacy projects" and discover candidates.
+
+Discovery is an active area of development. Current approaches include:
+
+| Approach | How It Works | Status |
+|----------|--------------|--------|
+| Direct sharing | Amira sends Ben her XID URL | Works now (T02-T04) |
+| Project directories | Maintainers list contributor XIDs | Manual curation |
+| Skill registries | Index attestations by `isA` type | Under development |
+| Web of trust crawling | Follow endorsement links | Under development |
+
+For now, discovery happens through existing channels: project READMEs, social introductions, conference talks, or forum posts. The XID provides the *verification* infrastructure; discovery tooling will make the ecosystem more navigable as it matures.
+
+> :brain: **Learn more**: Watch the [Blockchain Commons research repository](https://github.com/BlockchainCommons/research) for updates on discovery protocols and tooling.
+
+### Where Do Endorsements Live?
+
+Endorsements need to be published for discovery. Three approaches:
+
+| Approach | How It Works | Trade-off |
+|----------|--------------|-----------|
+| Amira's XIDDoc | Amira attaches endorsement | Amira controls visibility |
+| Charlene's XIDDoc | Charlene lists "I endorsed..." | Proves Charlene's commitment |
+| Elided commitment | Charlene publishes `ELIDED`, gives Amira full version | Maximum privacy (see T06) |
+
+The elided approach uses the same commit-reveal pattern from Tutorial 06. Charlene publishes an opaque commitment; Amira reveals the full endorsement when needed and proves it matches the public digest.
+
+### Endorsement Lifecycle
+
+Endorsements are point-in-time statements. Charlene's endorsement reflects what she observed through January 2026. If BRadvoc8's behavior changes, the endorsement doesn't automatically update. Some considerations: endorsements don't expire cryptographically, but evaluators should consider age; if Charlene needs to withdraw an endorsement, she can publish a revocation (a new signed statement superseding the old one); and diversifying endorsers protects against any single endorser becoming unreliable. The web of trust is resilient precisely because it doesn't depend on any single point of validation.
+
+---
+
+## Part V: Updating Your Claims After Endorsement
+
+Endorsements validate your claims. Once validated, you can update your attestations to reflect this stronger standing.
+
+### Step 8: Upgrade an Attestation
+
+Before endorsements, Amira's privacy attestation was a bare claim:
+
+> "I design privacy-preserving systems that protect vulnerable populations"
+
+After SecurityMaintainer endorsed her contributions, she can make a stronger claim:
+
+```
+# Create upgraded attestation referencing the endorsement
+UPGRADED_CLAIM=$(envelope subject type string "I delivered security enhancements (endorsed by SecurityMaintainer, Jan 2026)")
+
+UPGRADED_ATTESTATION=$(envelope assertion add pred-obj known isA string "SelfAttestation" "$UPGRADED_CLAIM")
+UPGRADED_ATTESTATION=$(envelope assertion add pred-obj string "attestedBy" string "BRadvoc8" "$UPGRADED_ATTESTATION")
+UPGRADED_ATTESTATION=$(envelope assertion add pred-obj string "attestedOn" date "2026-01-21T00:00:00Z" "$UPGRADED_ATTESTATION")
+UPGRADED_ATTESTATION=$(envelope assertion add pred-obj string "validatedBy" string "$MAINTAINER_XID_ID" "$UPGRADED_ATTESTATION")
+
+# Sign the upgraded attestation
+UPGRADED_ATTESTATION=$(envelope sign --signer "$XID_PRVKEYS" "$UPGRADED_ATTESTATION")
+
+echo "Upgraded attestation:"
+envelope format "$UPGRADED_ATTESTATION"
+
+│ "I delivered security enhancements (endorsed by SecurityMaintainer, Jan 2026)" [
+│     'isA': "SelfAttestation"
+│     "attestedBy": "BRadvoc8"
+│     "attestedOn": 2026-01-21T00:00:00Z
+│     "validatedBy": "ur:xid/hdcx..."
+│     'signed': Signature
+│ ]
+```
+
+The new attestation includes a `validatedBy` reference pointing to the endorser's XID. Anyone can verify both the claim and the endorsement.
+
+### Step 9: Advance Provenance
+
+After updating your public attestations, signal the change:
+
+```
+# Advance provenance to indicate updated profile
+UPDATED_XID=$(envelope xid provenance next "$UNWRAPPED_XID")
+
+echo "Provenance advanced - verifiers will know to fetch latest version"
+
+│ Provenance advanced - verifiers will know to fetch latest version
+```
+
+The provenance mark increments to signal that this identity has been updated. Anyone caching an old version will see the provenance mismatch and know to fetch the latest.
+
+> **Pattern**: Raw claim → Demonstrated work → Peer endorsement → Upgraded claim referencing endorsement. Each step strengthens credibility.
+
+---
+
+## Part VI: Wrap-Up
+
+### Save Your Work
+
+```
+echo "$CHARLENE_ENDORSEMENT" > "$OUTPUT_DIR/endorsement-charlene.envelope"
+echo "$TECH_ENDORSEMENT_SIGNED" > "$OUTPUT_DIR/endorsement-devreviewer.envelope"
+echo "$COLLAB_ENDORSEMENT_SIGNED" > "$OUTPUT_DIR/endorsement-maintainer.envelope"
+
+echo "Saved endorsements to $OUTPUT_DIR"
+ls "$OUTPUT_DIR"
+
+│ Saved endorsements to output/xid-tutorial08-20260121120000
+│ endorsement-charlene.envelope
+│ endorsement-devreviewer.envelope
+│ endorsement-maintainer.envelope
+```
+
+### What Amira Has Built
+
+**Progressive trust layers**:
+
+1. T01: Self-sovereign identity (XID exists)
+2. T02: Self-consistent (signature verifies, fresh)
+3. T03: Externally linked (GitHub, SSH key)
+4. T04: Cross-verified (external accounts confirmed)
+5. T05: Fair witness attestations (public, verifiable claims)
+6. T06: Sensitive claims managed (commit elided, reveal later)
+7. T07: Encrypted sharing (sensitive credentials to trusted recipients)
+8. T08: Peer validated (independent endorsements)
+
+The reputation is **portable** (follows her XID), **verifiable** (anyone can check), **privacy-preserving** (no legal identity), and **growing** (can continue building).
+
+---
+
+## Appendix: Key Terminology
+
+> **Peer Endorsement**: A signed statement someone else makes about you, providing independent validation.
+>
+> **Web of Trust**: Network of interconnected endorsements where trust propagates through relationships.
+>
+> **Endorsement Scope**: Explicit limitations on what an endorsement covers.
+>
+> **Relationship Transparency**: Explanation of how endorser knows the endorsed person.
+
+---
+
+## Common Questions
+
+### Q: How many endorsements do I need?
+
+**A:** Quality over quantity. Three strong endorsements from established community members with clear context are worth more than ten vague ones. Focus on endorsements from people with relevant expertise who can speak to specific aspects of your work.
+
+### Q: What if an endorser becomes disreputable?
+
+**A:** Endorsements are point-in-time statements. The endorsement remains cryptographically valid, but evaluators will consider the endorser's current standing. Diversify your endorsers so no single person is critical to your reputation. This resilience is a key benefit of the web of trust.
+
+### Q: Can I endorse others?
+
+**A:** Yes! Apply fair witness methodology: endorse only what you've directly observed, be specific about scope, and disclose your relationship. Your endorsement staking helps build the network—and strengthens your own reputation as a thoughtful evaluator.
+
+### Q: Can I warn others about a bad actor?
+
+**A:** Yes—a signed statement with relationship context and specific evidence is a negative endorsement. Use carefully: false accusations damage your own reputation, and vague warnings ("X is bad") carry little weight. Specific, documented concerns ("I observed X claim credentials they didn't have") are more valuable.
+
+### Q: What if I want to withdraw an endorsement?
+
+**A:** You can publish a revocation—a new signed statement that supersedes the original endorsement. Include a reference to the original's digest and explain why you're withdrawing it. The original endorsement doesn't disappear, but the revocation provides context for evaluators.
+
+---
+
+## Exercises
+
+1. Design an endorsement request for a real collaborator—what would you ask them to endorse, and what context would you provide?
+2. Write an endorsement for a fictional peer using fair witness methodology (direct observation, specific scope, relationship disclosure, acknowledged limitations)
+3. Evaluate endorsement quality: compare "X is great!" vs "I reviewed X's code for 6 months and merged 12 PRs"—what makes one better?
+4. Identify who could provide endorsements for different aspects of your work (technical, collaboration, character)
+5. Draft an endorsement you could honestly give someone today, being specific about what you've observed and what you can't speak to
+
+---
+
+**Previous**: [Encrypted Sharing](07-encrypted-sharing.md) | **Next**: [Binding Agreements](09-binding-agreements.md)

--- a/tutorials/09-binding-agreements.md
+++ b/tutorials/09-binding-agreements.md
@@ -1,0 +1,423 @@
+# Tutorial 09: Binding Agreements
+
+Sign a binding agreement pseudonymously to contribute to open source projects. This is the culmination of your identity journey—from anonymous person to trusted contributor.
+
+**Time to complete**: ~25-30 minutes
+**Difficulty**: Intermediate
+**Builds on**: Tutorials 01-08
+
+> **Related Concepts**: After completing this tutorial, explore [Progressive Trust](../concepts/progressive-trust.md) and [Herd Privacy](../concepts/herd-privacy.md) to deepen your understanding.
+
+## Prerequisites
+
+- Completed Tutorial 08 (Peer Endorsements)
+- The `envelope` CLI tool installed
+- Understanding of detached attestations and signatures
+
+## What You'll Learn
+
+- Why CLAs require a different approach than attestations
+- How to create **contract-signing keys** with limited permissions
+- The structure of a pseudonymous CLA
+- **Ben's verification workflow** for accepting contributions
+- How **herd privacy** protects pseudonymous contributors
+
+## Building on Tutorial 08
+
+| Tutorial 08 | Tutorial 09 |
+|-------------|-------------|
+| Others vouch for Amira | Amira makes binding commitments |
+| Endorsements (third-party) | Agreements (bilateral) |
+| Reputation established | Contribution enabled |
+
+**The Bridge**: In Tutorial 08, Amira received endorsements from Charlene, DevReviewer, and SecurityMaintainer. She now has a verifiable identity, demonstrated skills, and peer validation. But endorsements aren't contributions. To actually contribute to Ben's open source project, Amira needs to sign a Contributor License Agreement—pseudonymously but bindingly.
+
+---
+
+## Part I: Understanding CLAs
+
+### Why CLAs Are Different
+
+A CLA is structurally different from what we've built so far:
+
+| Type | Who Signs | Obligations |
+|------|-----------|-------------|
+| Self-attestation | You | One-way claim about yourself |
+| Peer endorsement | Someone else | One-way claim about you |
+| CLA | Both parties | Bilateral—you grant rights, maintainer accepts |
+
+Attestations and endorsements are unilateral statements. A CLA is a contract: Amira offers to grant certain rights, Ben accepts the offer. Both parties have obligations. This bilateral nature requires more careful handling.
+
+> :book: **Contributor License Agreement (CLA)**: A bilateral contract where contributors grant projects license to use their contributions under open source terms. Unlike attestations (one-way claims), CLAs create mutual obligations.
+
+### What a CLA Typically Grants
+
+| Provision | What It Means |
+|-----------|---------------|
+| Copyright license | Perpetual, worldwide, non-exclusive license to use your contributions |
+| Patent license | License to any patented technology in your contributions |
+| Authority representation | You have the legal right to grant these licenses |
+| Original work representation | Your contributions are original (or properly attributed) |
+
+Amira reads these terms carefully. She understands what she's agreeing to before signing.
+
+---
+
+## Part II: Contract-Signing Keys
+
+### Step 0: Verify Dependencies
+
+Ensure you have the required tools installed:
+
+```
+envelope --version
+
+│ bc-envelope-cli 0.32.0
+```
+
+If not installed, see Tutorial 01 Step 0 for installation instructions.
+
+### Step 1: Set Up Environment
+
+```
+OUTPUT_DIR="output/xid-tutorial09-$(date +%Y%m%d%H%M%S)"
+mkdir -p "$OUTPUT_DIR"
+
+# Create Amira's XID with provenance tracking
+XID=$(envelope generate keypairs --signing ed25519 | \
+    envelope xid new --nickname "BRadvoc8" --generator include --sign inception)
+
+UNWRAPPED_XID=$(envelope extract wrapped "$XID")
+XID_ID=$(envelope xid id "$UNWRAPPED_XID")
+
+echo "Amira's XID: $XID_ID"
+
+│ Amira's XID: ur:xid/hdcxhsktlbjzhspyfzhl...
+```
+
+### Step 2: Create a Purpose-Specific Contract Key
+
+For signing contracts, Amira creates a key with limited permissions. This follows the principle of least authority: her identity key can do anything, but her contract key can only sign.
+
+```
+# Generate contract-signing keys
+CONTRACT_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+CONTRACT_PUBKEYS=$(envelope generate pubkeys "$CONTRACT_PRVKEYS")
+
+echo "Contract-signing key created (limited to signing only)"
+
+│ Contract-signing key created (limited to signing only)
+```
+
+Why a separate key? If the contract key were somehow compromised, the damage is limited to signatures. An attacker couldn't use it to modify Amira's XID, revoke other keys, or perform identity management operations.
+
+> :book: **Principle of Least Authority**: Grant only the minimum permissions needed for a specific purpose. This limits the blast radius of any compromise—a leaked contract key can't affect identity management.
+
+### Step 3: Register the Contract Key with Purpose
+
+Amira adds the contract key to her XID with explicit purpose limitation:
+
+```
+# Add contract key with limited purpose
+CONTRACT_KEY_ASSERTION=$(envelope subject type string "ContractSigningKey")
+CONTRACT_KEY_ASSERTION=$(envelope assertion add pred-obj string "publicKey" string "$CONTRACT_PUBKEYS" "$CONTRACT_KEY_ASSERTION")
+CONTRACT_KEY_ASSERTION=$(envelope assertion add pred-obj string "purpose" string "CLA and legal document signing only" "$CONTRACT_KEY_ASSERTION")
+CONTRACT_KEY_ASSERTION=$(envelope assertion add pred-obj string "addedOn" date "2026-01-21T00:00:00Z" "$CONTRACT_KEY_ASSERTION")
+
+echo "Contract key registered with limited purpose"
+envelope format "$CONTRACT_KEY_ASSERTION"
+
+│ "ContractSigningKey" [
+│     "addedOn": 2026-01-21T00:00:00Z
+│     "publicKey": "ur:pubkeys/hdcx..."
+│     "purpose": "CLA and legal document signing only"
+│ ]
+```
+
+Anyone verifying Amira's CLA signature can see that this key was designated specifically for contract signing. The purpose limitation is part of the public record.
+
+> :brain: **Key management patterns**: This purpose-specific key is one example of key hierarchies. For more complex setups with master keys and operational keys, see [Tutorial 10: Multi-Device Identity](10-multi-device-identity.md).
+
+---
+
+## Part III: Signing the CLA
+
+### Step 4: Create the CLA Document
+
+Ben's project uses a standard Individual CLA. Amira creates an envelope containing the agreement terms and her acceptance:
+
+```
+# Create the CLA content
+CLA=$(envelope subject type string "Individual Contributor License Agreement")
+
+# Add the project information
+CLA=$(envelope assertion add pred-obj string "project" string "SecureAuth Library" "$CLA")
+CLA=$(envelope assertion add pred-obj string "projectMaintainer" string "Ben (SecurityMaintainer)" "$CLA")
+CLA=$(envelope assertion add pred-obj string "licenseType" string "Apache-2.0" "$CLA")
+
+# Add the grant terms
+CLA=$(envelope assertion add pred-obj string "grantsCopyrightLicense" string "perpetual, worldwide, non-exclusive, royalty-free" "$CLA")
+CLA=$(envelope assertion add pred-obj string "grantsPatentLicense" string "for contributions containing patentable technology" "$CLA")
+
+# Add contributor representations
+CLA=$(envelope assertion add pred-obj string "contributorRepresents" string "original work with authority to grant license" "$CLA")
+
+# Add contributor identity
+CLA=$(envelope assertion add pred-obj string "contributor" string "$XID_ID" "$CLA")
+CLA=$(envelope assertion add pred-obj string "contributorNickname" string "BRadvoc8" "$CLA")
+CLA=$(envelope assertion add pred-obj string "signedOn" date "2026-01-21T00:00:00Z" "$CLA")
+
+# Mark as agreement type
+CLA=$(envelope assertion add pred-obj known isA string "ContributorLicenseAgreement" "$CLA")
+
+echo "CLA document created:"
+envelope format "$CLA"
+
+│ "Individual Contributor License Agreement" [
+│     'isA': "ContributorLicenseAgreement"
+│     "contributor": "ur:xid/hdcx..."
+│     "contributorNickname": "BRadvoc8"
+│     "contributorRepresents": "original work with authority to grant license"
+│     "grantsCopyrightLicense": "perpetual, worldwide, non-exclusive, royalty-free"
+│     "grantsPatentLicense": "for contributions containing patentable technology"
+│     "licenseType": "Apache-2.0"
+│     "project": "SecureAuth Library"
+│     "projectMaintainer": "Ben (SecurityMaintainer)"
+│     "signedOn": 2026-01-21T00:00:00Z
+│ ]
+```
+
+### Step 5: Sign with Contract Key
+
+Amira signs the CLA with her contract-signing key:
+
+```
+CLA_SIGNED=$(envelope sign --signer "$CONTRACT_PRVKEYS" "$CLA")
+
+echo "CLA signed by BRadvoc8:"
+envelope format "$CLA_SIGNED"
+
+│ {
+│     "Individual Contributor License Agreement" [
+│         'isA': "ContributorLicenseAgreement"
+│         "contributor": "ur:xid/hdcx..."
+│         "contributorNickname": "BRadvoc8"
+│         "contributorRepresents": "original work with authority to grant license"
+│         "grantsCopyrightLicense": "perpetual, worldwide, non-exclusive, royalty-free"
+│         "grantsPatentLicense": "for contributions containing patentable technology"
+│         "licenseType": "Apache-2.0"
+│         "project": "SecureAuth Library"
+│         "projectMaintainer": "Ben (SecurityMaintainer)"
+│         "signedOn": 2026-01-21T00:00:00Z
+│     ]
+│ } [
+│     'signed': Signature
+│ ]
+```
+
+The signed CLA is now a binding commitment from BRadvoc8 to grant the specified licenses for any contributions to the SecureAuth Library project.
+
+---
+
+## Part IV: Ben's Verification Workflow
+
+### Step 6: Ben Receives and Verifies
+
+Ben receives Amira's signed CLA. His verification workflow has several steps:
+
+```
+# Ben verifies the signature
+echo "Ben's verification workflow:"
+echo "============================"
+
+echo "1. Verify signature..."
+envelope verify --verifier "$CONTRACT_PUBKEYS" "$CLA_SIGNED"
+
+│ 1. Verify signature...
+│ Signature valid
+```
+
+### What If Someone Forges a CLA?
+
+What happens if an attacker creates a fake CLA claiming to be from BRadvoc8?
+
+```
+# Attacker creates fake CLA
+FAKE_CLA=$(envelope subject type string "Individual Contributor License Agreement")
+FAKE_CLA=$(envelope assertion add pred-obj string "contributor" string "$XID_ID" "$FAKE_CLA")
+FAKE_CLA=$(envelope assertion add pred-obj string "contributorNickname" string "BRadvoc8" "$FAKE_CLA")
+
+# Attacker signs with their own key (not BRadvoc8's contract key)
+ATTACKER_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+FAKE_CLA_SIGNED=$(envelope sign --signer "$ATTACKER_PRVKEYS" "$FAKE_CLA")
+
+# Ben tries to verify against BRadvoc8's known contract key
+envelope verify --verifier "$CONTRACT_PUBKEYS" "$FAKE_CLA_SIGNED" 2>&1 || true
+
+│ Error: Signature verification failed
+```
+
+The forgery fails because the attacker can't produce a valid signature without BRadvoc8's private contract key. Anyone can *claim* to be BRadvoc8 in the CLA metadata, but only the cryptographic signature proves authenticity—and that requires Amira's actual key.
+
+Ben also confirms the contract key is registered in BRadvoc8's XID (checking purpose: "CLA and legal document signing only") and optionally reviews the endorsements from DevReviewer, SecurityMaintainer, and Charlene accumulated in Tutorial 08.
+
+### Step 7: Ben Accepts and Records
+
+Satisfied with the verification, Ben accepts the CLA and records it:
+
+```
+# Ben creates his acceptance
+ACCEPTANCE=$(envelope subject type string "CLA Acceptance")
+ACCEPTANCE=$(envelope assertion add pred-obj string "accepts" string "$(envelope digest "$CLA_SIGNED")" "$ACCEPTANCE")
+ACCEPTANCE=$(envelope assertion add pred-obj string "contributor" string "$XID_ID" "$ACCEPTANCE")
+ACCEPTANCE=$(envelope assertion add pred-obj string "contributorNickname" string "BRadvoc8" "$ACCEPTANCE")
+ACCEPTANCE=$(envelope assertion add pred-obj string "acceptedOn" date "2026-01-21T00:00:00Z" "$ACCEPTANCE")
+ACCEPTANCE=$(envelope assertion add pred-obj string "acceptedBy" string "Ben (SecurityMaintainer)" "$ACCEPTANCE")
+
+# Ben signs with his maintainer key
+BEN_PRVKEYS=$(envelope generate prvkeys --signing ed25519)
+BEN_PUBKEYS=$(envelope generate pubkeys "$BEN_PRVKEYS")
+
+ACCEPTANCE_SIGNED=$(envelope sign --signer "$BEN_PRVKEYS" "$ACCEPTANCE")
+
+echo "4. Record acceptance..."
+echo "   CLA accepted and recorded"
+envelope format "$ACCEPTANCE_SIGNED"
+
+│ 4. Record acceptance...
+│    CLA accepted and recorded
+│ {
+│     "CLA Acceptance" [
+│         "acceptedBy": "Ben (SecurityMaintainer)"
+│         "acceptedOn": 2026-01-21T00:00:00Z
+│         "accepts": "ur:digest/hdcx..."
+│         "contributor": "ur:xid/hdcx..."
+│         "contributorNickname": "BRadvoc8"
+│     ]
+│ } [
+│     'signed': Signature
+│ ]
+```
+
+Ben stores the signed CLA in his project repository alongside his acceptance. Both documents are now part of the project's legal record.
+
+With the CLA accepted, Ben grants BRadvoc8 limited repository access: push to feature branches, but not main. The access is tied to the pseudonymous identity that signed the CLA. Amira submits her first pull request—PR #847: Add constant-time comparison for auth tokens—and it's merged. The journey from anonymous person to trusted contributor is complete.
+
+---
+
+## Part V: Herd Privacy
+
+### Why Multiple Contributors Matter
+
+Amira isn't the only pseudonymous contributor. Ben's project has 50 contributors with signed CLAs: BRadvoc8, CryptoGuardian, SecureDevX, PrivacyFirst99, AuthExpert, and 45 others.
+
+This is herd privacy in action. When a project has many contributors, each pseudonymous signature blends with the others. Observers see 50 pseudonyms. They can't easily determine which one is the human rights worker, which is the student, which is the retiree. The crowd provides cover.
+
+> :book: **Herd Privacy**: Protection gained when many pseudonymous identities operate together, making any individual harder to identify. The larger the herd, the stronger the privacy.
+
+### The Privacy Properties
+
+| Contributors | Observer's Challenge |
+|--------------|---------------------|
+| 1 | Trivial to identify |
+| 10 | Difficult to identify |
+| 50 | Needle in haystack |
+| 500 | Effectively anonymous |
+
+Amira's contribution to SecureAuth Library is one of many. Her pseudonym blends into the community. Even if someone suspected "a human rights worker contributes to this project," they'd have 50 candidates to investigate.
+
+> :brain: **Learn more**: Herd privacy is a foundational concept in privacy-preserving systems. See [Herd Privacy](../concepts/herd-privacy.md) for the theory and [Progressive Trust](../concepts/progressive-trust.md) for how it relates to trust building.
+
+---
+
+## Part VI: Wrap-Up
+
+### Save Your Work
+
+```
+echo "$CLA_SIGNED" > "$OUTPUT_DIR/cla-signed-bradvoc8.envelope"
+echo "$ACCEPTANCE_SIGNED" > "$OUTPUT_DIR/cla-acceptance-ben.envelope"
+echo "$CONTRACT_PUBKEYS" > "$OUTPUT_DIR/contract-pubkeys.envelope"
+echo "$XID" > "$OUTPUT_DIR/BRadvoc8-xid.envelope"
+
+echo "Saved to $OUTPUT_DIR:"
+ls "$OUTPUT_DIR"
+
+│ Saved to output/xid-tutorial09-20260121120000:
+│ BRadvoc8-xid.envelope
+│ cla-acceptance-ben.envelope
+│ cla-signed-bradvoc8.envelope
+│ contract-pubkeys.envelope
+```
+
+### First Arc Complete: Anonymous → Contributor
+
+Through nine tutorials, Amira built complete pseudonymous infrastructure: a self-sovereign identity (T01), made verifiable and fresh (T02), linked to external credentials (T03-04), demonstrated through public and private attestations (T05-07), validated by peer endorsements (T08), and finally enabled for contribution through a signed CLA (T09).
+
+BRadvoc8 can now do advocacy work that sustains her, blending into a community of contributors who all operate pseudonymously.
+
+**This completes the first arc**: from anonymous person to trusted contributor. Amira has everything she needs to participate in open source projects while protecting her real-world identity.
+
+| Arc | Tutorials | Outcome |
+|-----|-----------|---------|
+| **Identity → Contribution** | T01-T09 | ✅ Can contribute pseudonymously |
+| **Security Hardening** | T10-T12 | Protect identity from compromise |
+| **Advanced Collaboration** | T13+ | Group communication, clubs |
+
+The remaining tutorials (T10+) cover **advanced security topics**: multi-device key management, offline master keys, and compromise recovery. These are important for long-term identity protection but not required to start contributing.
+
+---
+
+## Appendix: Key Terminology
+
+> **Contract-Signing Key**: A purpose-limited key designated for signing legal documents, following the principle of least authority.
+>
+> **Bilateral Agreement**: A contract where both parties have obligations, unlike unilateral attestations or endorsements.
+
+See inline `:book:` callouts for definitions of CLA, Principle of Least Authority, and Herd Privacy.
+
+---
+
+## Common Questions
+
+### Q: Is a pseudonymous CLA legally binding?
+
+**A:** Yes, in most jurisdictions. What matters legally is that the signer intended to be bound and had capacity to contract. The signature doesn't need to be a legal name—it needs to be attributable to a specific entity making a commitment. Cryptographic signatures from a persistent pseudonymous identity satisfy this requirement.
+
+### Q: What if my employer owns my contributions?
+
+**A:** The CLA includes a representation that you have authority to grant the license. If your employment agreement assigns your work to your employer, you may need employer approval before contributing. This applies equally to pseudonymous and real-name contributors.
+
+> :warning: **Employment Agreements**: Many tech employment contracts include IP assignment clauses. Review your agreement before contributing—the CLA representation of authority is legally binding.
+
+### Q: Can access be revoked? What if I stop contributing?
+
+**A:** Repository access and the CLA license are separate. Ben can revoke access if you violate project policies, but your existing contributions remain licensed. Conversely, you can stop contributing anytime—the CLA covers past contributions, not future obligations.
+
+### Q: Why not just use a real name?
+
+**A:** For Amira, revealing her real name could endanger her. For others, it might affect employment, invite harassment, or simply be unnecessary. Pseudonymous contribution lets people participate based on the quality of their work, not their real-world identity.
+
+---
+
+## Exercises
+
+1. Create a CLA for a fictional project you maintain, specifying what license terms you'd require
+2. Design a key hierarchy with separate keys for: identity management, attestation signing, and contract signing
+3. Research how major open source projects (Apache, Linux Foundation) handle CLAs—what terms do they include?
+
+---
+
+## What's Next
+
+**You can start contributing now.** T01-T09 provides everything needed for pseudonymous open source contribution.
+
+**For enhanced security** (recommended for high-value identities):
+
+- **[Tutorial 10: Multi-Device Identity](10-multi-device-identity.md)** — Add operational keys so device compromise doesn't mean identity loss
+- **[Tutorial 11: Offline Master Key](11-offline-master-key.md)** — Move your master key offline using SSKR backup
+- **[Tutorial 12: Compromise Response](12-compromise-response.md)** — Recover from key compromise while preserving your identity
+
+**For group collaboration**:
+
+- **[Tutorial 13: Gordian Clubs](13-gordian-clubs.md)** — Secure group communication and shared secrets


### PR DESCRIPTION
## Summary

Completes the first tutorial arc (T01-T09) with five new tutorials and consistency improvements across all tutorials.

### New Tutorials

- **T05: Fair Witness Attestations** - Professional third-party credentials with lifecycle patterns (superseding/retraction)
- **T06: Managing Sensitive Claims** - Selective disclosure using elision and commitment patterns
- **T07: Encrypted Sharing** - Recipient-specific encryption for confidential information
- **T08: Peer Endorsements** - Building web of trust through mutual attestation
- **T09: Binding Agreements** - CLA signing with herd privacy considerations

### T01-T04 Improvements

- Difficulty ratings in headers
- Standardized appendix naming (Appendix: Key Terminology)
- Common Questions sections added
- `:brain:` "Learn more" markers for concept depth
- Consistent navigation links (Previous | Next)

### Test Coverage

- Updated T01 test script
- New comprehensive test scripts for T05-T09

All tutorials follow consistent structure and pass their test scripts.

## Test Plan

- [ ] Run test scripts for T01-T09
- [ ] Verify navigation links between tutorials
- [ ] Check envelope CLI commands execute correctly